### PR TITLE
updated security group target APIs

### DIFF
--- a/ibm/provider_test.go
+++ b/ibm/provider_test.go
@@ -344,7 +344,7 @@ func init() {
 	isImage = os.Getenv("IS_IMAGE")
 	if isImage == "" {
 		//isImage = "fc538f61-7dd6-4408-978c-c6b85b69fe76" // for classic infrastructure
-		isImage = "r006-5b05b4fe-bcbc-4309-ad45-3354813227a0" // for next gen infrastructure
+		isImage = "r134-9573cb89-984e-45a4-bfc5-df611bbb8e7d" // for next gen infrastructure
 		fmt.Println("[INFO] Set the environment variable IS_IMAGE for testing ibm_is_instance, ibm_is_floating_ip else it is set to default value 'r006-ed3f775f-ad7e-4e37-ae62-7199b4988b00'")
 	}
 

--- a/ibm/resource_ibm_is_instance.go
+++ b/ibm/resource_ibm_is_instance.go
@@ -1594,11 +1594,11 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if len(add) > 0 {
 			networkID := d.Get("primary_network_interface.0.id").(string)
 			for i := range add {
-				createsgnicoptions := &vpcv1.AddSecurityGroupNetworkInterfaceOptions{
+				createsgnicoptions := &vpcv1.CreateSecurityGroupTargetBindingOptions{
 					SecurityGroupID: &add[i],
 					ID:              &networkID,
 				}
-				_, response, err := instanceC.AddSecurityGroupNetworkInterface(createsgnicoptions)
+				_, response, err := instanceC.CreateSecurityGroupTargetBinding(createsgnicoptions)
 				if err != nil {
 					return fmt.Errorf("Error while creating security group %q for primary network interface of instance %s\n%s: %q", add[i], d.Id(), err, response)
 				}
@@ -1612,11 +1612,11 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		if len(remove) > 0 {
 			networkID := d.Get("primary_network_interface.0.id").(string)
 			for i := range remove {
-				deletesgnicoptions := &vpcv1.RemoveSecurityGroupNetworkInterfaceOptions{
+				deletesgnicoptions := &vpcv1.DeleteSecurityGroupTargetBindingOptions{
 					SecurityGroupID: &remove[i],
 					ID:              &networkID,
 				}
-				response, err := instanceC.RemoveSecurityGroupNetworkInterface(deletesgnicoptions)
+				response, err := instanceC.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 				if err != nil {
 					return fmt.Errorf("Error while removing security group %q for primary network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
 				}
@@ -1673,11 +1673,11 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 					networkIDKey := fmt.Sprintf("network_interfaces.%d.id", i)
 					networkID := d.Get(networkIDKey).(string)
 					for i := range add {
-						createsgnicoptions := &vpcv1.AddSecurityGroupNetworkInterfaceOptions{
+						createsgnicoptions := &vpcv1.CreateSecurityGroupTargetBindingOptions{
 							SecurityGroupID: &add[i],
 							ID:              &networkID,
 						}
-						_, response, err := instanceC.AddSecurityGroupNetworkInterface(createsgnicoptions)
+						_, response, err := instanceC.CreateSecurityGroupTargetBinding(createsgnicoptions)
 						if err != nil {
 							return fmt.Errorf("Error while creating security group %q for network interface of instance %s\n%s: %q", add[i], d.Id(), err, response)
 						}
@@ -1692,11 +1692,11 @@ func instanceUpdate(d *schema.ResourceData, meta interface{}) error {
 					networkIDKey := fmt.Sprintf("network_interfaces.%d.id", i)
 					networkID := d.Get(networkIDKey).(string)
 					for i := range remove {
-						deletesgnicoptions := &vpcv1.RemoveSecurityGroupNetworkInterfaceOptions{
+						deletesgnicoptions := &vpcv1.DeleteSecurityGroupTargetBindingOptions{
 							SecurityGroupID: &remove[i],
 							ID:              &networkID,
 						}
-						response, err := instanceC.RemoveSecurityGroupNetworkInterface(deletesgnicoptions)
+						response, err := instanceC.DeleteSecurityGroupTargetBinding(deletesgnicoptions)
 						if err != nil {
 							return fmt.Errorf("Error while removing security group %q for network interface of instance %s\n%s: %q", remove[i], d.Id(), err, response)
 						}

--- a/ibm/resource_ibm_is_instance_test.go
+++ b/ibm/resource_ibm_is_instance_test.go
@@ -44,6 +44,40 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 	})
 }
 
+func TestAccIBMISInstanceWithSecurityGroup_basic(t *testing.T) {
+	var instance string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instnace-%d", acctest.RandIntRange(10, 100))
+	secGrpName := fmt.Sprintf("tf-secgrp-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISInstanceWithSecurityGroupConfig(vpcname, subnetname, sshname, publicKey, secGrpName, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", ISZoneName),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "primary_network_interface.0.security_groups.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "network_interfaces.0.security_groups.#"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIBMISInstance_profile(t *testing.T) {
 	var instance string
 	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
@@ -394,6 +428,47 @@ func testAccCheckIBMISInstanceConfig(vpcname, subnetname, sshname, publicKey, na
 		}
 	  }`, vpcname, subnetname, ISZoneName, ISCIDR, sshname, publicKey, name, isImage, instanceProfileName, ISZoneName)
 }
+
+func testAccCheckIBMISInstanceWithSecurityGroupConfig(vpcname, subnetname, sshname, publicKey, secgrpname, name string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+	  }
+	  
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%s"
+		ipv4_cidr_block = "%s"
+	  }
+	  
+	  resource "ibm_is_ssh_key" "testacc_sshkey" {
+		name       = "%s"
+		public_key = "%s"
+	  }
+	  resource "ibm_is_security_group" "testacc_security_group" {
+		name = "%s"
+		vpc  = ibm_is_vpc.testacc_vpc.id
+	  }
+	  resource "ibm_is_instance" "testacc_instance" {
+		name    = "%s"
+		image   = "%s"
+		profile = "%s"
+		primary_network_interface {
+		  subnet     = ibm_is_subnet.testacc_subnet.id
+		  security_groups = [ibm_is_security_group.testacc_security_group.id]
+		}
+		vpc  = ibm_is_vpc.testacc_vpc.id
+		zone = "%s"
+		keys = [ibm_is_ssh_key.testacc_sshkey.id]
+		network_interfaces {
+		  subnet = ibm_is_subnet.testacc_subnet.id
+		  name   = "eth1"
+		  security_groups = [ibm_is_security_group.testacc_security_group.id]
+		}
+	  }`, vpcname, subnetname, ISZoneName, ISCIDR, sshname, publicKey, secgrpname, name, isImage, instanceProfileName, ISZoneName)
+}
+
 func testAccCheckIBMISInstanceSnapshotRestoreConfig(vpcname, subnetname, sshname, publicKey, name, snapshot, insRestore string) string {
 	return fmt.Sprintf(`
 	resource "ibm_is_vpc" "testacc_vpc" {

--- a/ibm/resource_ibm_is_security_group_network_interface_attachment.go
+++ b/ibm/resource_ibm_is_security_group_network_interface_attachment.go
@@ -5,6 +5,7 @@ package ibm
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -158,11 +159,11 @@ func resourceIBMISSecurityGroupNetworkInterfaceAttachmentCreate(d *schema.Resour
 	sgID := d.Get(isSGNICAGroupId).(string)
 	nicID := d.Get(isSGNICANicId).(string)
 
-	options := &vpcv1.AddSecurityGroupNetworkInterfaceOptions{
+	options := &vpcv1.CreateSecurityGroupTargetBindingOptions{
 		SecurityGroupID: &sgID,
 		ID:              &nicID,
 	}
-	_, response, err := sess.AddSecurityGroupNetworkInterface(options)
+	_, response, err := sess.CreateSecurityGroupTargetBinding(options)
 	if err != nil {
 		return fmt.Errorf("Error while creating SecurityGroup NetworkInterface Binding %s\n%s", err, response)
 	}
@@ -183,17 +184,27 @@ func resourceIBMISSecurityGroupNetworkInterfaceAttachmentRead(d *schema.Resource
 	sgID := parts[0]
 	nicID := parts[1]
 
-	getSecurityGroupNetworkInterfaceOptions := &vpcv1.GetSecurityGroupNetworkInterfaceOptions{
+	getSecurityGroupNetworkInterfaceOptions := &vpcv1.GetSecurityGroupTargetOptions{
 		SecurityGroupID: &sgID,
 		ID:              &nicID,
 	}
-	instanceNic, response, err := sess.GetSecurityGroupNetworkInterface(getSecurityGroupNetworkInterfaceOptions)
+	secGroupTarget, response, err := sess.GetSecurityGroupTarget(getSecurityGroupNetworkInterfaceOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}
-		return fmt.Errorf("Error getting NetworkInterface(%s) for the SecurityGroup (%s) : %s\n%s", nicID, sgID, err, response)
+		return fmt.Errorf("Error getting target(%s) for the SecurityGroup (%s) : %s\n%s", nicID, sgID, err, response)
+	}
+	instance_id := strings.Split(*secGroupTarget.(*vpcv1.SecurityGroupTargetReference).Href, "/")[5]
+	net_interf_id := *secGroupTarget.(*vpcv1.SecurityGroupTargetReference).ID
+	getnicoptions := &vpcv1.GetInstanceNetworkInterfaceOptions{
+		InstanceID: &instance_id,
+		ID:         &net_interf_id,
+	}
+	instanceNic, response, err := sess.GetInstanceNetworkInterface(getnicoptions)
+	if err != nil {
+		return fmt.Errorf("Error getting network interfaces attached to the instance %s %s\n%s", instance_id, err, response)
 	}
 	d.Set(isSGNICAGroupId, sgID)
 	d.Set(isSGNICANicId, nicID)
@@ -251,11 +262,11 @@ func resourceIBMISSecurityGroupNetworkInterfaceAttachmentDelete(d *schema.Resour
 	sgID := parts[0]
 	nicID := parts[1]
 
-	getSecurityGroupNetworkInterfaceOptions := &vpcv1.GetSecurityGroupNetworkInterfaceOptions{
+	getSecurityGroupNetworkInterfaceOptions := &vpcv1.GetSecurityGroupTargetOptions{
 		SecurityGroupID: &sgID,
 		ID:              &nicID,
 	}
-	_, response, err := sess.GetSecurityGroupNetworkInterface(getSecurityGroupNetworkInterfaceOptions)
+	_, response, err := sess.GetSecurityGroupTarget(getSecurityGroupNetworkInterfaceOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			d.SetId("")
@@ -264,11 +275,11 @@ func resourceIBMISSecurityGroupNetworkInterfaceAttachmentDelete(d *schema.Resour
 		return fmt.Errorf("Error getting NetworkInterface(%s) for the SecurityGroup (%s) : %s\n%s", nicID, sgID, err, response)
 	}
 
-	removeSecurityGroupNetworkInterfaceOptions := &vpcv1.RemoveSecurityGroupNetworkInterfaceOptions{
+	removeSecurityGroupNetworkInterfaceOptions := &vpcv1.DeleteSecurityGroupTargetBindingOptions{
 		SecurityGroupID: &sgID,
 		ID:              &nicID,
 	}
-	response, err = sess.RemoveSecurityGroupNetworkInterface(removeSecurityGroupNetworkInterfaceOptions)
+	response, err = sess.DeleteSecurityGroupTargetBinding(removeSecurityGroupNetworkInterfaceOptions)
 	if err != nil {
 		return fmt.Errorf("Error Deleting NetworkInterface(%s) for the SecurityGroup (%s) : %s\n%s", nicID, sgID, err, response)
 	}
@@ -290,11 +301,11 @@ func resourceIBMISSecurityGroupNetworkInterfaceAttachmentExists(d *schema.Resour
 	}
 	sgID := parts[0]
 	nicID := parts[1]
-	getSecurityGroupNetworkInterfaceOptions := &vpcv1.GetSecurityGroupNetworkInterfaceOptions{
+	getSecurityGroupNetworkInterfaceOptions := &vpcv1.GetSecurityGroupTargetOptions{
 		SecurityGroupID: &sgID,
 		ID:              &nicID,
 	}
-	_, response, err := sess.GetSecurityGroupNetworkInterface(getSecurityGroupNetworkInterfaceOptions)
+	_, response, err := sess.GetSecurityGroupTarget(getSecurityGroupNetworkInterfaceOptions)
 	if err != nil {
 		if response != nil && response.StatusCode == 404 {
 			return false, nil

--- a/ibm/resource_ibm_is_security_group_network_interface_attachment_test.go
+++ b/ibm/resource_ibm_is_security_group_network_interface_attachment_test.go
@@ -90,15 +90,15 @@ func testAccCheckIBMISSecurityGroupNwInterfaceAttachmentExists(n, instance strin
 		nicID := parts[1]
 
 		sess, _ := testAccProvider.Meta().(ClientSession).VpcV1API()
-		getsgnicptions := &vpcv1.GetSecurityGroupNetworkInterfaceOptions{
+		getsgnicptions := &vpcv1.GetSecurityGroupTargetOptions{
 			SecurityGroupID: &sgID,
 			ID:              &nicID,
 		}
-		found, _, err := sess.GetSecurityGroupNetworkInterface(getsgnicptions)
+		found, _, err := sess.GetSecurityGroupTarget(getsgnicptions)
 		if err != nil {
 			return err
 		}
-		instance = *found.ID
+		instance = *found.(*vpcv1.SecurityGroupTargetReference).ID
 		return nil
 	}
 }

--- a/website/docs/r/is_security_group_network_interface_attachment.html.markdown
+++ b/website/docs/r/is_security_group_network_interface_attachment.html.markdown
@@ -18,6 +18,7 @@ resource "ibm_is_security_group_network_interface_attachment" "sgnic" {
   network_interface = "6d6128aa-badc-45c4-bb0e-7c2c1c47be55"
 }
 ```
+**Note** This resource is deprecated. Use `ibm_is_security_group_target` to attach a network interface to a security group
 
 ## Argument reference
 Review the argument references that you can specify for your resource. 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.
<img width="520" alt="Screen Shot 2021-07-16 at 7 16 23 PM" src="https://user-images.githubusercontent.com/77007253/125973831-7b55443b-f00a-4b90-9057-1e9da459a300.png">
<img width="520" alt="Screen Shot 2021-07-16 at 7 42 07 PM" src="https://user-images.githubusercontent.com/77007253/125973835-d0ae77aa-4e83-4ea6-a828-9c6a0e0aab5f.png">
<img width="520" alt="Screen Shot 2021-07-16 at 8 01 08 PM" src="https://user-images.githubusercontent.com/77007253/125973842-ade8308e-0b20-43c2-acb5-0655075df28f.png">

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'


...
```
