### PR TITLE
UI-17494: added tagging and access tags support for is_snapshot

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -2239,6 +2239,42 @@ func ResourceTagsCustomizeDiff(diff *schema.ResourceDiff) error {
 	return nil
 }
 
+func ResourceValidateAccessTags(diff *schema.ResourceDiff, meta interface{}) error {
+
+	if value, ok := diff.GetOkExists("access_tags"); ok {
+		tagSet := value.(*schema.Set)
+		newTagList := tagSet.List()
+		tagType := "access"
+		gtClient, err := meta.(conns.ClientSession).GlobalTaggingAPIv1()
+		if err != nil {
+			return fmt.Errorf("Error getting global tagging client settings: %s", err)
+		}
+
+		listTagsOptions := &globaltaggingv1.ListTagsOptions{
+			TagType: &tagType,
+		}
+		taggingResult, _, err := gtClient.ListTags(listTagsOptions)
+		if err != nil {
+			return err
+		}
+		var taglist []string
+		for _, item := range taggingResult.Items {
+			taglist = append(taglist, *item.Name)
+		}
+		existingAccessTags := NewStringSet(ResourceIBMVPCHash, taglist)
+		errStatement := ""
+		for _, tag := range newTagList {
+			if !existingAccessTags.Contains(tag) {
+				errStatement = errStatement + " " + tag.(string)
+			}
+		}
+		if errStatement != "" {
+			return fmt.Errorf("[ERROR] Error : Access tag(s) %s does not exist", errStatement)
+		}
+	}
+	return nil
+}
+
 func ResourceLBListenerPolicyCustomizeDiff(diff *schema.ResourceDiff) error {
 	policyActionIntf, _ := diff.GetOk(isLBListenerPolicyAction)
 	policyAction := policyActionIntf.(string)

--- a/ibm/service/vpc/data_source_ibm_is_snapshot.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshot.go
@@ -5,6 +5,7 @@ package vpc
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
@@ -48,6 +49,14 @@ func DataSourceSnapshot() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "If present, the image id from which the data on this volume was most directly provisioned.",
+			},
+
+			isSnapshotAccessTags: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         flex.ResourceIBMVPCHash,
+				Description: "List of access tags",
 			},
 
 			isSnapshotOperatingSystem: {
@@ -259,6 +268,12 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 					backupPolicyPlanList = append(backupPolicyPlanList, backupPolicyPlan)
 				}
 				d.Set(isSnapshotBackupPolicyPlan, backupPolicyPlanList)
+				accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *snapshot.CRN, "", isAccessTagType)
+				if err != nil {
+					log.Printf(
+						"Error on get of resource snapshot (%s) access tags: %s", d.Id(), err)
+				}
+				d.Set(isSnapshotAccessTags, accesstags)
 				return nil
 			}
 		}
@@ -319,6 +334,12 @@ func snapshotGetByNameOrID(d *schema.ResourceData, meta interface{}, name, id st
 			backupPolicyPlanList = append(backupPolicyPlanList, backupPolicyPlan)
 		}
 		d.Set(isSnapshotBackupPolicyPlan, backupPolicyPlanList)
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *snapshot.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource snapshot (%s) access tags: %s", d.Id(), err)
+		}
+		d.Set(isSnapshotAccessTags, accesstags)
 		return nil
 	}
 }

--- a/ibm/service/vpc/data_source_ibm_is_snapshots.go
+++ b/ibm/service/vpc/data_source_ibm_is_snapshots.go
@@ -5,6 +5,7 @@ package vpc
 
 import (
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
@@ -155,6 +156,14 @@ func DataSourceSnapshots() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Set:         flex.ResourceIBMVPCHash,
 							Description: "User Tags for the snapshot",
+						},
+
+						isSnapshotAccessTags: {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Set:         flex.ResourceIBMVPCHash,
+							Description: "List of access tags",
 						},
 
 						isSnapshotBackupPolicyPlan: {
@@ -311,6 +320,12 @@ func getSnapshots(d *schema.ResourceData, meta interface{}) error {
 			backupPolicyPlanList = append(backupPolicyPlanList, backupPolicyPlan)
 		}
 		l[isSnapshotBackupPolicyPlan] = backupPolicyPlanList
+		accesstags, err := flex.GetGlobalTagsUsingCRN(meta, *snapshot.CRN, "", isAccessTagType)
+		if err != nil {
+			log.Printf(
+				"Error on get of resource snapshot (%s) access tags: %s", d.Id(), err)
+		}
+		l[isSnapshotAccessTags] = accesstags
 		snapshotsInfo = append(snapshotsInfo, l)
 	}
 	d.SetId(dataSourceIBMISSnapshotsID(d))

--- a/website/docs/d/is_snapshot.html.markdown
+++ b/website/docs/d/is_snapshot.html.markdown
@@ -89,7 +89,7 @@ Review the argument references that you can specify for your data source.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your data source is created.
-
+- `access_tags`  - (Array of Strings) Access management tags associated with the snapshot.
 - `backup_policy_plan` - (List) If present, the backup policy plan which created this snapshot.
   
    Nested scheme for `backup_policy_plan`:

--- a/website/docs/d/is_snapshots.html.markdown
+++ b/website/docs/d/is_snapshots.html.markdown
@@ -47,6 +47,7 @@ In addition to all argument reference list, you can access the following attribu
 - `snapshots` - (List) List of snapshots in the IBM Cloud Infrastructure.
   
   Nested scheme for `snapshots`:
+  - `access_tags`  - (Array of Strings) Access management tags associated with the snapshot.
   - `id` - (String) The unique identifier for this snapshot.
   - `backup_policy_plan` - (List) If present, the backup policy plan which created this snapshot.
   

--- a/website/docs/r/is_snapshot.html.markdown
+++ b/website/docs/r/is_snapshot.html.markdown
@@ -78,6 +78,12 @@ The `ibm_is_snapshot` resource provides the following [Timeouts](https://www.ter
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
+- `access_tags`  - (Optional, List of Strings) A list of access management tags to attach to the subnet.
+  **Note:**
+    - You can attach only those access tags that already exists.
+    - For more information, about creating access tags, see [working with tags](https://cloud.ibm.com/docs/account?topic=account-tag&interface=ui#create-access-console).
+    - You must have the access listed in the [Granting users access to tag resources](https://cloud.ibm.com/docs/account?topic=account-access) for `access_tags`
+    - `access_tags` must be in the format `key:value`.
 - `name` - (Optional, String) The name of the snapshot.
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID where the snapshot is to be created
 - `source_volume` - (Required, Forces new resource, String) The unique identifier for the volume for which snapshot is to be created. 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
resource "ibm_is_snapshot" "testacc_snapshot" {
  name          = "sunitha-snapshot"
  source_volume = "r006-159e42ba-cff8-4448-965b-e618c12e9a4c"
  access_tags   = []
}

data "ibm_is_snapshot" "ds_snapshot" {
  depends_on = [ibm_is_snapshot.testacc_snapshot]
  name       = "sunitha-snapshot"
}

data "ibm_is_snapshots" "ds_snapshot" {
  depends_on = [ibm_is_snapshot.testacc_snapshot]
  name = "sunitha-snapshot"
}
```
<img width="568" alt="Screenshot 2022-10-31 at 12 45 44 PM" src="https://user-images.githubusercontent.com/78336632/198952913-f4240fc9-4bcd-4e77-9798-5437a7c304ca.png">
<img width="560" alt="Screenshot 2022-10-31 at 12 51 00 PM" src="https://user-images.githubusercontent.com/78336632/198953149-7a240a4e-273e-4d17-afbf-f8a2d9bf70fe.png">
<img width="661" alt="Screenshot 2022-10-31 at 12 50 55 PM" src="https://user-images.githubusercontent.com/78336632/198953177-bdc3bcc3-ed04-475f-9b84-e0cd84bf1547.png">
