### PR TITLE
added logic to set port speed in primary nic

### DIFF
--- a/ibm/data_source_ibm_is_floating_ip_test.go
+++ b/ibm/data_source_ibm_is_floating_ip_test.go
@@ -64,7 +64,6 @@ func testAccCheckIBMISFloatingIPDataSourceConfig(vpcname, subnetname, sshname, p
 		image   = "%s"
 		profile = "%s"
 		primary_network_interface {
-		  port_speed = "100"
 		  subnet     = ibm_is_subnet.testacc_subnet.id
 		}
 		vpc  = ibm_is_vpc.testacc_vpc.id

--- a/ibm/data_source_ibm_is_instance.go
+++ b/ibm/data_source_ibm_is_instance.go
@@ -609,6 +609,9 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 				if err != nil {
 					return fmt.Errorf("Error getting network interfaces attached to the instance %s\n%s", err, response)
 				}
+				if insnic.PortSpeed != nil {
+					currentPrimNic[isInstanceNicPortSpeed] = *insnic.PortSpeed
+				}
 				currentPrimNic[isInstanceNicSubnet] = *insnic.Subnet.ID
 				if len(insnic.SecurityGroups) != 0 {
 					secgrpList := []string{}

--- a/ibm/data_source_ibm_is_instance_test.go
+++ b/ibm/data_source_ibm_is_instance_test.go
@@ -30,6 +30,8 @@ func TestAccIBMISInstanceDataSource_basic(t *testing.T) {
 						resName, "name", instanceName),
 					resource.TestCheckResourceAttr(
 						resName, "tags.#", "1"),
+					resource.TestCheckResourceAttrSet(
+						resName, "primary_network_interface.0.port_speed"),
 				),
 			},
 		},
@@ -59,7 +61,6 @@ resource "ibm_is_instance" "testacc_instance" {
   image   = "%s"
   profile = "%s"
   primary_network_interface {
-    port_speed = "100"
     subnet     = ibm_is_subnet.testacc_subnet.id
   }
   vpc  = ibm_is_vpc.testacc_vpc.id

--- a/ibm/resource_ibm_is_floating_ip_test.go
+++ b/ibm/resource_ibm_is_floating_ip_test.go
@@ -151,7 +151,6 @@ func testAccCheckIBMISFloatingIPConfig(vpcname, subnetname, sshname, publicKey, 
 		image   = "%s"
 		profile = "%s"
 		primary_network_interface {
-		  port_speed = "100"
 		  subnet     = ibm_is_subnet.testacc_subnet.id
 		}
 		user_data = "%s"

--- a/ibm/resource_ibm_is_instance.go
+++ b/ibm/resource_ibm_is_instance.go
@@ -1601,6 +1601,9 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 			return fmt.Errorf("Error getting network interfaces attached to the instance %s\n%s", err, response)
 		}
 		currentPrimNic[isInstanceNicAllowIPSpoofing] = *insnic.AllowIPSpoofing
+		if insnic.PortSpeed != nil {
+			currentPrimNic[isInstanceNicPortSpeed] = *insnic.PortSpeed
+		}
 		currentPrimNic[isInstanceNicSubnet] = *insnic.Subnet.ID
 		if len(insnic.SecurityGroups) != 0 {
 			secgrpList := []string{}

--- a/ibm/resource_ibm_is_instance_test.go
+++ b/ibm/resource_ibm_is_instance_test.go
@@ -55,6 +55,8 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_instance.testacc_instance", "user_data", userData2),
 					resource.TestCheckResourceAttr(
 						"ibm_is_instance.testacc_instance", "zone", ISZoneName),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "primary_network_interface.0.port_speed"),
 				),
 			},
 		},

--- a/ibm/resource_ibm_is_lb_pool_member_test.go
+++ b/ibm/resource_ibm_is_lb_pool_member_test.go
@@ -221,7 +221,6 @@ func testAccCheckIBMISLBPoolMemberIDConfig(vpcname, subnetname, zone, cidr, sshn
 		image   = data.ibm_is_image.ds_image.id
 		profile = "%s"
 		primary_network_interface {
-		  port_speed = "100"
 		  subnet     = ibm_is_subnet.testacc_subnet.id
 		}
 		vpc  = ibm_is_vpc.testacc_vpc.id

--- a/website/docs/r/is_floating_ip.html.markdown
+++ b/website/docs/r/is_floating_ip.html.markdown
@@ -32,7 +32,6 @@ resource "ibm_is_instance" "testacc_instance" {
   profile = "b-2x8"
 
   primary_network_interface {
-    port_speed = "1000"
     subnet     = "70be8eae-134c-436e-a86e-04849f84cb34"
   }
 

--- a/website/docs/r/is_flow_log.html.markdown
+++ b/website/docs/r/is_flow_log.html.markdown
@@ -32,7 +32,6 @@ resource "ibm_is_instance" "testacc_instance" {
   profile = "b-2x8"
 
   primary_network_interface {
-    port_speed = "1000"
     subnet     = "70be8eae-134c-436e-a86e-04849f84cb34"
   }
 

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -309,7 +309,6 @@ Review the argument references that you can specify for your resource.
       - Use this only if you have **IP spoofing operator** access.
 
   - `name` - (Optional, String) The name of the network interface.
-  - `port_speed` - (Deprecated, Integer) Speed of the network interface.
   - `primary_ipv4_address` - (Optional, Forces new resource, String) The IPV4 address of the interface.
   - `subnet` - (Required, String) The ID of the subnet.
   - `security_groups`-List of strings-Optional-A comma separated list of security groups to add to the primary network interface.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISFloatingIPDataSource_basic (468.64s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 472.872s
```
