### PR TITLE
Datasource vpc address prefix

### DIFF
--- a/examples/ibm-is-ng/main.tf
+++ b/examples/ibm-is-ng/main.tf
@@ -706,3 +706,20 @@ data "ibm_is_placement_groups" "is_placement_groups" {
 ## List regions 
 data "ibm_is_regions" "regions" {
 }
+
+data "ibm_is_vpc_address_prefix" "example" {
+  vpc = ibm_is_vpc.vpc1.id
+  address_prefix = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.address_prefix
+}
+data "ibm_is_vpc_address_prefix" "example-1" {
+  vpc_name = ibm_is_vpc.vpc1.name
+  address_prefix = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.address_prefix
+}
+data "ibm_is_vpc_address_prefix" "example-2" {
+  vpc = ibm_is_vpc.vpc1.id
+  address_prefix_name = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.name
+}
+data "ibm_is_vpc_address_prefix" "example-3" {
+  vpc_name = ibm_is_vpc.vpc1.name
+  address_prefix_name = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.name
+}

--- a/ibm/data_source_ibm_is_vpc_address_prefix.go
+++ b/ibm/data_source_ibm_is_vpc_address_prefix.go
@@ -1,0 +1,237 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+)
+
+func dataSourceIBMIsVPCAddressPrefix() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMIsVPCAddressPrefixRead,
+
+		Schema: map[string]*schema.Schema{
+			"vpc": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"vpc", "vpc_name"},
+				Description:  "The VPC identifier.",
+			},
+			"vpc_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"vpc", "vpc_name"},
+				Description:  "The VPC name.",
+			},
+			"address_prefix": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"address_prefix", "address_prefix_name"},
+				Description:  "The address prefix identifier.",
+			},
+			"address_prefix_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ExactlyOneOf: []string{"address_prefix", "address_prefix_name"},
+				Description:  "The address prefix name.",
+			},
+			"cidr": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The CIDR block for this prefix.",
+			},
+			"created_at": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the prefix was created.",
+			},
+			"has_subnets": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether subnets exist with addresses from this prefix.",
+			},
+			"href": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this address prefix.",
+			},
+			"is_default": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates whether this is the default prefix for this zone in this VPC. If a default prefix was automatically created when the VPC was created, the prefix is automatically named using a hyphenated list of randomly-selected words, but may be updated with a user-specified name.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.",
+			},
+			"zone": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "The zone this address prefix resides in.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"href": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this zone.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The globally unique name for this zone.",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceIBMIsVPCAddressPrefixRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vpcClient, err := meta.(ClientSession).VpcV1API()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	vpc_id := d.Get("vpc").(string)
+	address_prefix_id := d.Get("address_prefix").(string)
+	address_prefix_name := d.Get("address_prefix_name").(string)
+	vpc_name := d.Get("vpc_name").(string)
+	var addressPrefix *vpcv1.AddressPrefix
+	if vpc_id == "" {
+		start := ""
+		allrecs := []vpcv1.VPC{}
+		for {
+			listVpcsOptions := &vpcv1.ListVpcsOptions{}
+			if start != "" {
+				listVpcsOptions.Start = &start
+			}
+			vpcs, response, err := vpcClient.ListVpcs(listVpcsOptions)
+			if err != nil {
+				return diag.FromErr(fmt.Errorf("Error Fetching vpcs %s\n%s", err, response))
+			}
+			start = GetNext(vpcs.Next)
+			allrecs = append(allrecs, vpcs.Vpcs...)
+			if start == "" {
+				break
+			}
+		}
+		vpc_found := false
+		for _, vpc := range allrecs {
+			if *vpc.Name == vpc_name {
+				vpc_id = *vpc.ID
+				vpc_found = true
+				break
+			}
+		}
+		if !vpc_found {
+			log.Printf("[DEBUG] VPC with given name not found %s\n", vpc_name)
+			return diag.FromErr(fmt.Errorf("VPC with given name not found %s\n", vpc_name))
+		}
+	}
+	if address_prefix_id != "" {
+		getVPCAddressPrefixOptions := &vpcv1.GetVPCAddressPrefixOptions{}
+
+		getVPCAddressPrefixOptions.SetVPCID(vpc_id)
+		getVPCAddressPrefixOptions.SetID(address_prefix_id)
+
+		addressPrefix1, response, err := vpcClient.GetVPCAddressPrefixWithContext(context, getVPCAddressPrefixOptions)
+		if err != nil {
+			log.Printf("[DEBUG] GetVPCAddressPrefixWithContext failed %s\n%s", err, response)
+			return diag.FromErr(fmt.Errorf("GetVPCAddressPrefixWithContext failed %s\n%s", err, response))
+		}
+		addressPrefix = addressPrefix1
+
+	} else {
+		start := ""
+		allrecs := []vpcv1.AddressPrefix{}
+		listVpcAddressPrefixesOptions := &vpcv1.ListVPCAddressPrefixesOptions{}
+
+		listVpcAddressPrefixesOptions.SetVPCID(vpc_id)
+		for {
+			if start != "" {
+				listVpcAddressPrefixesOptions.Start = &start
+			}
+			addressPrefixCollection, response, err := vpcClient.ListVPCAddressPrefixesWithContext(context, listVpcAddressPrefixesOptions)
+			if err != nil {
+				log.Printf("[DEBUG] ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
+				return diag.FromErr(fmt.Errorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response))
+			}
+			start = GetNext(addressPrefixCollection.Next)
+			allrecs = append(allrecs, addressPrefixCollection.AddressPrefixes...)
+			if start == "" {
+				break
+			}
+		}
+		address_prefix_found := false
+		for _, addressPrefixItem := range allrecs {
+			if *addressPrefixItem.Name == address_prefix_name {
+				addressPrefix = &addressPrefixItem
+				address_prefix_found = true
+				break
+			}
+		}
+		if !address_prefix_found {
+			log.Printf("[DEBUG] Address Prefix with given name not found %s\n", address_prefix_name)
+			return diag.FromErr(fmt.Errorf("Address Prefix with given name not found %s\n", address_prefix_name))
+		}
+	}
+	d.SetId(*addressPrefix.ID)
+	if err = d.Set("cidr", addressPrefix.CIDR); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting cidr: %s", err))
+	}
+
+	if err = d.Set("created_at", dateTimeToString(addressPrefix.CreatedAt)); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting created_at: %s", err))
+	}
+
+	if err = d.Set("has_subnets", addressPrefix.HasSubnets); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting has_subnets: %s", err))
+	}
+
+	if err = d.Set("href", addressPrefix.Href); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting href: %s", err))
+	}
+
+	if err = d.Set("is_default", addressPrefix.IsDefault); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting is_default: %s", err))
+	}
+
+	if err = d.Set("name", addressPrefix.Name); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting name: %s", err))
+	}
+
+	zone := []map[string]interface{}{}
+	if addressPrefix.Zone != nil {
+		modelMap, err := dataSourceIBMIsVPCAddressPrefixZoneReferenceToMap(addressPrefix.Zone)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		zone = append(zone, modelMap)
+	}
+	if err = d.Set("zone", zone); err != nil {
+		return diag.FromErr(fmt.Errorf("Error setting zone %s", err))
+	}
+
+	return nil
+}
+
+func dataSourceIBMIsVPCAddressPrefixZoneReferenceToMap(model *vpcv1.ZoneReference) (map[string]interface{}, error) {
+	modelMap := make(map[string]interface{})
+	if model.Href != nil {
+		modelMap["href"] = model.Href
+	}
+	if model.Name != nil {
+		modelMap["name"] = model.Name
+	}
+	return modelMap, nil
+}

--- a/ibm/data_source_ibm_is_vpc_address_prefix_test.go
+++ b/ibm/data_source_ibm_is_vpc_address_prefix_test.go
@@ -1,0 +1,103 @@
+// Copyright IBM Corp. 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package ibm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMIsVPCAddressPrefixDataSourceBasic(t *testing.T) {
+	name := fmt.Sprintf("tfvpcuat-%d", acctest.RandIntRange(10, 100))
+	prefixName := fmt.Sprintf("tfaddprename-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMIsVPCAddressPrefixDataSourceConfigBasic(name, prefixName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "cidr"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "has_subnets"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "is_default"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix", "zone.#"),
+				),
+			},
+			{
+				Config: testAccCheckIBMIsVPCAddressPrefixDataSourceConfigBasic(name, prefixName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix1", "cidr"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix1", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix1", "has_subnets"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix1", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix1", "is_default"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix1", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix1", "zone.#"),
+				),
+			},
+			{
+				Config: testAccCheckIBMIsVPCAddressPrefixDataSourceConfigBasic(name, prefixName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix2", "cidr"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix2", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix2", "has_subnets"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix2", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix2", "is_default"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix2", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix2", "zone.#"),
+				),
+			},
+			{
+				Config: testAccCheckIBMIsVPCAddressPrefixDataSourceConfigBasic(name, prefixName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix3", "cidr"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix3", "created_at"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix3", "has_subnets"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix3", "href"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix3", "is_default"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix3", "name"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_vpc_address_prefix.is_vpc_address_prefix3", "zone.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIBMIsVPCAddressPrefixDataSourceConfigBasic(name, prefixName string) string {
+	return fmt.Sprintf(`
+	resource "ibm_is_vpc" "testacc_vpc" {
+		name = "%s"
+		address_prefix_management = "manual"
+	}
+	resource "ibm_is_vpc_address_prefix" "testacc_vpc_address_prefix" {
+		name = "%s"
+		zone = "%s"
+		vpc = "${ibm_is_vpc.testacc_vpc.id}"
+		cidr = "%s"
+		is_default = true
+	}
+	data "ibm_is_vpc_address_prefix" "is_vpc_address_prefix" {
+		vpc = ibm_is_vpc.testacc_vpc.id
+		address_prefix = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.address_prefix
+	}
+	data "ibm_is_vpc_address_prefix" "is_vpc_address_prefix1" {
+		vpc_name = ibm_is_vpc.testacc_vpc.name
+		address_prefix = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.address_prefix
+	}
+	data "ibm_is_vpc_address_prefix" "is_vpc_address_prefix2" {
+		vpc = ibm_is_vpc.testacc_vpc.id
+		address_prefix_name = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.name
+	}
+	data "ibm_is_vpc_address_prefix" "is_vpc_address_prefix3" {
+		vpc_name = ibm_is_vpc.testacc_vpc.name
+		address_prefix_name = ibm_is_vpc_address_prefix.testacc_vpc_address_prefix.name
+	}
+	`, name, prefixName, ISZoneName, ISAddressPrefixCIDR)
+}

--- a/ibm/provider.go
+++ b/ibm/provider.go
@@ -361,6 +361,7 @@ func Provider() *schema.Provider {
 			"ibm_is_vpcs":                            dataSourceIBMISVPCs(),
 			"ibm_is_vpn_gateways":                    dataSourceIBMISVPNGateways(),
 			"ibm_is_vpc_address_prefixes":            dataSourceIbmIsVpcAddressPrefixes(),
+			"ibm_is_vpc_address_prefix":              dataSourceIBMIsVPCAddressPrefix(),
 			"ibm_is_vpn_gateway_connections":         dataSourceIBMISVPNGatewayConnections(),
 			"ibm_is_vpc_default_routing_table":       dataSourceIBMISVPCDefaultRoutingTable(),
 			"ibm_is_vpc_routing_tables":              dataSourceIBMISVPCRoutingTables(),

--- a/ibm/resource_ibm_is_vpc_address_prefix.go
+++ b/ibm/resource_ibm_is_vpc_address_prefix.go
@@ -17,6 +17,7 @@ const (
 	isVPCAddressPrefixVPCID      = "vpc"
 	isVPCAddressPrefixHasSubnets = "has_subnets"
 	isVPCAddressPrefixDefault    = "is_default"
+	isAddressPrefix              = "address_prefix"
 )
 
 func resourceIBMISVpcAddressPrefix() *schema.Resource {
@@ -74,6 +75,12 @@ func resourceIBMISVpcAddressPrefix() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The crn of the VPC resource",
+			},
+
+			isAddressPrefix: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The unique identifier of the address prefix",
 			},
 		},
 	}
@@ -153,6 +160,7 @@ func vpcAddressPrefixCreate(d *schema.ResourceData, meta interface{}, name, zone
 
 	addrPrefixID := *addrPrefix.ID
 	d.SetId(fmt.Sprintf("%s/%s", vpcID, addrPrefixID))
+	d.Set(isAddressPrefix, addrPrefixID)
 	return nil
 }
 
@@ -197,6 +205,7 @@ func vpcAddressPrefixGet(d *schema.ResourceData, meta interface{}, vpcID, addrPr
 	}
 	d.Set(isVPCAddressPrefixCIDR, *addrPrefix.CIDR)
 	d.Set(isVPCAddressPrefixHasSubnets, *addrPrefix.HasSubnets)
+	d.Set(isAddressPrefix, addrPrefixID)
 	getVPCOptions := &vpcv1.GetVPCOptions{
 		ID: &vpcID,
 	}

--- a/website/docs/d/is_vpc_address_prefix.html.markdown
+++ b/website/docs/d/is_vpc_address_prefix.html.markdown
@@ -1,0 +1,71 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : ibm_is_vpc_address_prefix"
+description: |-
+  Get information about VPC Address Prefix
+---
+
+# ibm_is_vpc_address_prefix
+
+Provides a read-only data source for VPC Address Prefix. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```hcl
+data "ibm_is_vpc_address_prefix" "example" {
+  vpc = ibm_is_vpc.example.id
+  address_prefix = ibm_is_vpc_address_prefix.example.address_prefix
+}
+data "ibm_is_vpc_address_prefix" "example-1" {
+  vpc_name = ibm_is_vpc.example.name
+  address_prefix = ibm_is_vpc_address_prefix.example.address_prefix
+}
+data "ibm_is_vpc_address_prefix" "example-2" {
+  vpc = ibm_is_vpc.example.id
+  address_prefix_name = ibm_is_vpc_address_prefix.example.name
+}
+data "ibm_is_vpc_address_prefix" "example-3" {
+  vpc_name = ibm_is_vpc.example.name
+  address_prefix_name = ibm_is_vpc_address_prefix.example.name
+}
+```
+
+## Argument Reference
+
+Review the argument reference that you can specify for your data source.
+
+- `address_prefix` - (String) The address prefix identifier.
+- `address_prefix_name` - (String) The address prefix name.
+
+~> **Note:**
+  Provide exactly one of `address_prefix`, `address_prefix_name`
+
+- `vpc` - (String) The VPC identifier
+- `vpc_name` - (String) Name of the VPC
+  
+  ~> **Note:**
+  Provide exactly one of `vpc`, `vpc_name`
+
+## Attribute Reference
+
+In addition to all argument references listed, you can access the following attribute references after your data source is created.
+
+- `id` - (String) The unique identifier of the AddressPrefix.
+- `cidr` - (String) The CIDR block for this prefix.
+
+- `created_at` - (String) The date and time that the prefix was created.
+
+- `has_subnets` - (Boolean) Indicates whether subnets exist with addresses from this prefix.
+
+- `href` - (String) The URL for this address prefix.
+
+- `is_default` - (Boolean) Indicates whether this is the default prefix for this zone in this VPC. If a default prefix was automatically created when the VPC was created, the prefix is automatically named using a hyphenated list of randomly-selected words, but may be updated with a user-specified name.
+
+- `name` - (String) The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.
+
+- `zone` - (List) The zone this address prefix resides in.
+  Nested scheme for **zone**:
+	- `href` - (String) The URL for this zone.
+	- `name` - (String) The globally unique name for this zone.
+

--- a/website/docs/d/is_vpc_address_prefixes.html.markdown
+++ b/website/docs/d/is_vpc_address_prefixes.html.markdown
@@ -1,12 +1,12 @@
 ---
 subcategory: "VPC infrastructure"
 layout: "ibm"
-page_title: "IBM : is_vpc_address_prefix"
+page_title: "IBM : is_vpc_address_prefixes"
 description: |-
   Get information about VPC address prefixes
 ---
 
-# ibm_is_vpc_address_prefix
+# ibm_is_vpc_address_prefixes
 
 Retrieve information of an existing IBM Cloud address prefix collection. For more information, about VPC address prefix, see [address prefixes](https://cloud.ibm.com/docs/vpc?topic=vpc-vpc-behind-the-curtain#address-prefixes).
 
@@ -41,19 +41,19 @@ In addition to all argument reference list, you can access the following attribu
 
 - `address_prefixes` - (List) Collection of the address prefixes.
 
-Nested `address_prefixes` blocks have the following structure:
-- `created_at` - (Timestamp) The date and time that the prefix was created.
-- `cidr` - (String) The CIDR block for this prefix.
-- `has_subnets` - (String) Indicates whether subnets exist with addresses from this prefix.
-- `href` - (String) The URL for this address prefix.
-- `id` - (String) The unique identifier for this address prefix.
-- `is_default` - (String) Indicates whether this is the default prefix for this zone in this VPC. If a default prefix was automatically created when the VPC was created, the prefix is automatically named using a hyphenated list of randomly-selected words, but may be updated with a user-specified name.
-- `name` - (String) The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.
-- `zone` - (List) The zone this address prefix resides in.
-
-Nested `zone` blocks have the following structure:
-- `href` - (String) The URL for this zone.
-- `name` - (String) The globally unique name for this zone.
-
-- `id` - (String) The unique identifier of the AddressPrefixCollection.
-- `total_count` - (String) The total number of resources across all pages.
+  Nested `address_prefixes` blocks have the following structure:
+  - `created_at` - (Timestamp) The date and time that the prefix was created.
+  - `cidr` - (String) The CIDR block for this prefix.
+  - `has_subnets` - (String) Indicates whether subnets exist with addresses from this prefix.
+  - `href` - (String) The URL for this address prefix.
+  - `id` - (String) The unique identifier for this address prefix.
+  - `is_default` - (String) Indicates whether this is the default prefix for this zone in this VPC. If a default prefix was automatically created when the VPC was created, the prefix is automatically named using a hyphenated list of randomly-selected words, but may be updated with a user-specified name.
+  - `name` - (String) The user-defined name for this address prefix. Names must be unique within the VPC the address prefix resides in.
+  - `zone` - (List) The zone this address prefix resides in.
+  
+      Nested `zone` blocks have the following structure:
+      - `href` - (String) The URL for this zone.
+      - `name` - (String) The globally unique name for this zone.
+  
+  - `id` - (String) The unique identifier of the AddressPrefixCollection.
+  - `total_count` - (String) The total number of resources across all pages.

--- a/website/docs/r/is_vpc_address_prefix.html.markdown
+++ b/website/docs/r/is_vpc_address_prefix.html.markdown
@@ -51,8 +51,9 @@ Review the argument references that you can specify for your resource.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.
 
-- `id` - (String) The ID of the address prefix.
+- `id` - (String) The ID of the address prefix. The ID is composed of `<vpc_id>/<address_prefix_id>`.
 - `has_subnets`- (Bool) Indicates whether subnets exist with addresses from this prefix.
+- `address_prefix` - (String) the unique identifier of the address prefix.
 
 ## Import
 The `ibm_is_vpc_address_prefix` resource can be imported by using the VPC ID and VPC address prefix ID.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm TESTARGS='-run=TestAccIBMIsVPCAddressPrefixDataSourceBasic'
=== RUN   TestAccIBMIsVPCAddressPrefixDataSourceBasic
--- PASS: TestAccIBMIsVPCAddressPrefixDataSourceBasic (263.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm 266.450s
...
```
