### PR TITLE
fix: instance network interface mutex sync

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance_network_interface.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_network_interface.go
@@ -337,7 +337,7 @@ func resourceIBMIsInstanceNetworkInterfaceCreate(context context.Context, d *sch
 		}
 	}
 
-	isNICKey := "instance_network_interface_key_" + instance_id
+	isNICKey := "instance_key_" + instance_id
 	conns.IbmMutexKV.Lock(isNICKey)
 	defer conns.IbmMutexKV.Unlock(isNICKey)
 
@@ -621,7 +621,7 @@ func resourceIBMIsInstanceNetworkInterfaceUpdate(context context.Context, d *sch
 		hasChange = true
 	}
 	if hasChange {
-		isNICKey := "instance_network_interface_key_" + instance_id
+		isNICKey := "instance_key_" + instance_id
 		conns.IbmMutexKV.Lock(isNICKey)
 		defer conns.IbmMutexKV.Unlock(isNICKey)
 		updateInstanceNetworkInterfaceOptions.NetworkInterfacePatch, _ = patchVals.AsPatch()
@@ -710,7 +710,7 @@ func resourceIBMIsInstanceNetworkInterfaceDelete(context context.Context, d *sch
 	}
 	instance_id := parts[0]
 	network_intf_id := parts[1]
-	isNICKey := "instance_network_interface_key_" + instance_id
+	isNICKey := "instance_key_" + instance_id
 	conns.IbmMutexKV.Lock(isNICKey)
 	defer conns.IbmMutexKV.Unlock(isNICKey)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
