### PR TITLE
fix(security_groups): removed deprecated network interfaces field from security groups list datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_security_groups.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_groups.go
@@ -73,55 +73,6 @@ func DataSourceIBMIsSecurityGroups() *schema.Resource {
 							Computed:    true,
 							Description: "The user-defined name for this security group. Names must be unique within the VPC the security group resides in.",
 						},
-						"network_interfaces": &schema.Schema{
-							Type:        schema.TypeList,
-							Computed:    true,
-							Deprecated:  "This argument is deprecated",
-							Description: "The network interfaces for this security group.",
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"deleted": &schema.Schema{
-										Type:        schema.TypeList,
-										Computed:    true,
-										Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
-										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"more_info": &schema.Schema{
-													Type:        schema.TypeString,
-													Computed:    true,
-													Description: "Link to documentation about deleted resources.",
-												},
-											},
-										},
-									},
-									"href": &schema.Schema{
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The URL for this network interface.",
-									},
-									"id": &schema.Schema{
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The unique identifier for this network interface.",
-									},
-									"name": &schema.Schema{
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The user-defined name for this network interface.",
-									},
-									"primary_ipv4_address": &schema.Schema{
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The primary IPv4 address.If the address has not yet been selected, the value will be `0.0.0.0`.",
-									},
-									"resource_type": &schema.Schema{
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: "The resource type.",
-									},
-								},
-							},
-						},
 						"resource_group": &schema.Schema{
 							Type:        schema.TypeList,
 							Computed:    true,
@@ -436,14 +387,6 @@ func dataSourceSecurityGroupCollectionSecurityGroupsToMap(securityGroupsItem *vp
 	if securityGroupsItem.Name != nil {
 		resultMap["name"] = securityGroupsItem.Name
 	}
-	if securityGroupsItem.NetworkInterfaces != nil {
-		var mapSlice []map[string]interface{}
-		for _, listElem := range securityGroupsItem.NetworkInterfaces {
-			mapElem := dataSourceSecurityGroupCollectionSecurityGroupsNetworkInterfacesToMap(&listElem)
-			mapSlice = append(mapSlice, mapElem)
-		}
-		resultMap["network_interfaces"] = mapSlice
-	}
 	if securityGroupsItem.ResourceGroup != nil {
 		var mapSlice []map[string]interface{}
 		modelMap := dataSourceSecurityGroupCollectionSecurityGroupsResourceGroupToMap(securityGroupsItem.ResourceGroup)
@@ -471,44 +414,6 @@ func dataSourceSecurityGroupCollectionSecurityGroupsToMap(securityGroupsItem *vp
 		modelMap := dataSourceSecurityGroupCollectionSecurityGroupsVPCToMap(securityGroupsItem.VPC)
 		mapSlice = append(mapSlice, modelMap)
 		resultMap["vpc"] = mapSlice
-	}
-
-	return resultMap
-}
-
-func dataSourceSecurityGroupCollectionSecurityGroupsNetworkInterfacesToMap(networkInterfacesItem *vpcv1.NetworkInterfaceReference) (resultMap map[string]interface{}) {
-	resultMap = map[string]interface{}{}
-
-	if networkInterfacesItem.Deleted != nil {
-		var mapSlice []map[string]interface{}
-		modelMap := dataSourceSecurityGroupCollectionNetworkInterfacesDeletedToMap(networkInterfacesItem.Deleted)
-		mapSlice = append(mapSlice, modelMap)
-		resultMap["deleted"] = mapSlice
-	}
-	if networkInterfacesItem.Href != nil {
-		resultMap["href"] = networkInterfacesItem.Href
-	}
-	if networkInterfacesItem.ID != nil {
-		resultMap["id"] = networkInterfacesItem.ID
-	}
-	if networkInterfacesItem.Name != nil {
-		resultMap["name"] = networkInterfacesItem.Name
-	}
-	if networkInterfacesItem.PrimaryIpv4Address != nil {
-		resultMap["primary_ipv4_address"] = networkInterfacesItem.PrimaryIpv4Address
-	}
-	if networkInterfacesItem.ResourceType != nil {
-		resultMap["resource_type"] = networkInterfacesItem.ResourceType
-	}
-
-	return resultMap
-}
-
-func dataSourceSecurityGroupCollectionNetworkInterfacesDeletedToMap(deletedItem *vpcv1.NetworkInterfaceReferenceDeleted) (resultMap map[string]interface{}) {
-	resultMap = map[string]interface{}{}
-
-	if deletedItem.MoreInfo != nil {
-		resultMap["more_info"] = deletedItem.MoreInfo
 	}
 
 	return resultMap
@@ -753,45 +658,6 @@ func dataSourceSecurityGroupCollectionVPCDeletedToMap(deletedItem *vpcv1.VPCRefe
 	return resultMap
 }
 
-func dataSourceSecurityGroupsRuleFlattenRemote(m vpcv1.SecurityGroupRuleRemoteIntf) (ruleList []map[string]interface{}) {
-	ruleList = []map[string]interface{}{}
-	ruleMap := dataSourceSecurityGroupsRuleRemoteToMap(m.(*vpcv1.SecurityGroupRuleRemote))
-	ruleList = append(ruleList, ruleMap)
-	return ruleList
-}
-
-func dataSourceSecurityGroupsRuleRemoteToMap(remoteItem *vpcv1.SecurityGroupRuleRemote) (remoteMap map[string]interface{}) {
-	remoteMap = map[string]interface{}{}
-
-	if remoteItem.Address != nil {
-		remoteMap["address"] = *remoteItem.Address
-	}
-
-	if remoteItem.CIDRBlock != nil {
-		remoteMap["cidr_block"] = *remoteItem.CIDRBlock
-	}
-	if remoteItem.CRN != nil {
-		remoteMap["crn"] = *remoteItem.CRN
-	}
-	if remoteItem.Deleted != nil {
-		remoteDeletedList := []map[string]interface{}{}
-		remoteDeletedMap := dataSourceSecurityGroupCollectionRemoteDeletedToMap(remoteItem.Deleted)
-		remoteDeletedList = append(remoteDeletedList, remoteDeletedMap)
-		remoteMap["deleted"] = remoteDeletedList
-	}
-
-	if remoteItem.Href != nil {
-		remoteMap["href"] = *remoteItem.Href
-	}
-	if remoteItem.ID != nil {
-		remoteMap["id"] = *remoteItem.ID
-	}
-	if remoteItem.Name != nil {
-		remoteMap["name"] = *remoteItem.Name
-	}
-
-	return remoteMap
-}
 func dataSourceSecurityGroupsRemoteToMap(remoteItem vpcv1.SecurityGroupRuleRemote) (remoteMap map[string]interface{}) {
 	remoteMap = map[string]interface{}{}
 

--- a/ibm/service/vpc/data_source_ibm_is_security_groups_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_groups_test.go
@@ -24,7 +24,6 @@ func TestAccIBMIsSecurityGroupsDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_security_groups.example", "security_groups.0.crn"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_security_groups.example", "security_groups.0.href"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_security_groups.example", "security_groups.0.name"),
-					resource.TestCheckResourceAttrSet("data.ibm_is_security_groups.example", "security_groups.0.network_interfaces.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_security_groups.example", "security_groups.0.resource_group.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_security_groups.example", "security_groups.0.rules.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_security_groups.example", "security_groups.0.targets.#"),

--- a/website/docs/d/is_security_groups.html.markdown
+++ b/website/docs/d/is_security_groups.html.markdown
@@ -13,8 +13,8 @@ For more information, about security group, see API Docs(https://cloud.ibm.com/d
 
 ## Example Usage
 
-```hcl
-  data "ibm_is_security_groups" "example" {
+```terraform
+data "ibm_is_security_groups" "example" {
 }
 ```
 
@@ -22,7 +22,7 @@ OR with Filters:
 
 Filter with VPC name
 
-```hcl
+```terraform
 data "ibm_is_security_groups" "example" {
   vpc_name = ibm_is_vpc.example.name
 }
@@ -30,14 +30,14 @@ data "ibm_is_security_groups" "example" {
 
 Filter with VPC ID
 
-```hcl
+```terraform
 data "ibm_is_security_groups" "example" {
   vpc_id = ibm_is_vpc.example.id
 }
 ```
 
 Filter with VPC CRN
-```hcl
+```terraform
 data "ibm_is_security_groups" "example" {
   vpc_crn = ibm_is_vpc.example.crn
 }
@@ -45,12 +45,11 @@ data "ibm_is_security_groups" "example" {
 
 Filter with Resource Group ID
 
-```hcl
+```terraform
 data "ibm_is_security_groups" "example" {
   resource_group= data.ibm_resource_group.default.id
 }
 ```
-
 
 
 ## Attribute Reference
@@ -69,16 +68,6 @@ Nested scheme for `security_groups`:
 	- `href` - (String) The security group's canonical URL.
 	- `id` - (String) The unique identifier for this security group.
 	- `name` - (String) The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
-	- `network_interfaces` - (Deprecated, List) The network interfaces for this security group.
-	Nested scheme for `network_interfaces`:
-		- `deleted` - (List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.
-		Nested scheme for `deleted`:
-			- `more_info` - (String) Link to documentation about deleted resources.
-		- `href` - (String) The URL for this network interface.
-		- `id` - (String) The unique identifier for this network interface.
-		- `name` - (String) The user-defined name for this network interface.
-		- `primary_ipv4_address` - (String) The primary IPv4 address.If the address has not yet been selected, the value will be `0.0.0.0`.
-		- `resource_type` - (String) The resource type.
 	- `resource_group` - (List) The resource group for this security group.
 	Nested scheme for `resource_group`:
 		- `href` - (String) The URL for this resource group.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMIsSecurityGroupsDataSourceBasic (40.21s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     41.857s
```
