### PR TITLE
Fix for optional weight attribute's value

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_pool_member.go
@@ -164,9 +164,7 @@ func resourceIBMISLBPoolMemberCreate(d *schema.ResourceData, meta interface{}) e
 	port64 := int64(port)
 
 	var weight int64
-	if w, ok := d.GetOkExists(isLBPoolMemberWeight); ok {
-		weight = int64(w.(int))
-	}
+
 	isLBKey := "load_balancer_key_" + lbID
 	conns.IbmMutexKV.Lock(isLBKey)
 	defer conns.IbmMutexKV.Unlock(isLBKey)
@@ -213,7 +211,12 @@ func lbpMemberCreate(d *schema.ResourceData, meta interface{}, lbID, lbPoolID st
 		}
 		options.Target = target
 	}
-	options.Weight = &weight
+	if w, ok := d.GetOkExists(isLBPoolMemberWeight); ok {
+		weight = int64(w.(int))
+		if ok {
+			options.Weight = &weight
+		}
+	}
 
 	lbPoolMember, response, err := sess.CreateLoadBalancerPoolMember(options)
 	if err != nil {


### PR DESCRIPTION
Fix for optional weight attr set to 0 when not provided.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #UI-21513
https://jiracloud.swg.usma.ibm.com:8443/browse/UI-21513
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISLBPoolMember_basic_opt_weight_check'
=== RUN   TestAccIBMISLBPoolMember_basic_opt_weight_check
--- PASS: TestAccIBMISLBPoolMember_basic_opt_weight_check (807.13s)
PASS
ok  	github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc	808.130s

...
```
