### PR TITLE
Bug subnet datasource

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_subnets.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnets.go
@@ -96,6 +96,49 @@ func DataSourceIBMISSubnets() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"routing_table": {
+							Type:        schema.TypeList,
+							Computed:    true,
+							Description: "The routing table for this subnet",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"deleted": {
+										Type:        schema.TypeList,
+										Computed:    true,
+										Description: "If present, this property indicates the referenced resource has been deleted and providessome supplementary information.",
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"more_info": {
+													Type:        schema.TypeString,
+													Computed:    true,
+													Description: "Link to documentation about deleted resources.",
+												},
+											},
+										},
+									},
+									"href": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The URL for this routing table.",
+									},
+									"id": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The unique identifier for this routing table.",
+									},
+									"name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The user-defined name for this routing table.",
+									},
+									"resource_type": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The resource type.",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -181,6 +224,9 @@ func subnetList(d *schema.ResourceData, meta interface{}) error {
 		}
 		if subnet.ResourceGroup != nil {
 			l["resource_group"] = *subnet.ResourceGroup.ID
+		}
+		if subnet.RoutingTable != nil {
+			l["routing_table"] = dataSourceSubnetFlattenroutingTable(*subnet.RoutingTable)
 		}
 		subnetsInfo = append(subnetsInfo, l)
 	}

--- a/ibm/service/vpc/data_source_ibm_is_subnets_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_subnets_test.go
@@ -158,6 +158,7 @@ func testAccCheckIBMISSubnetsDataSourceFilterResourceGroupConfig(vpcname, name, 
 	}
 	  
 	data "ibm_is_subnets" "ds_subnets_resource_group" {
+		depends_on = [ibm_is_subnet.testacc_subnet]
 		resource_group = data.ibm_resource_group.resourceGroup.id
 	}
 	`, vpcname, name, zone, cidr)
@@ -190,7 +191,8 @@ func testAccCheckIBMISSubnetsDataSourceFilterRoutingTableConfig(vpcname, name, z
 	}
 	  
 	data "ibm_is_subnets" "ds_subnets_routing_table" {
-		routing_table = ibm_is_vpc_routing_table.test_cr_route_table1.id
+		depends_on = [ibm_is_subnet.testacc_subnet ]
+		routing_table = ibm_is_vpc_routing_table.test_cr_route_table1.routing_table
 	}
 	`, vpcname, name, zone, cidr)
 }

--- a/website/docs/d/is_subnet.html.markdown
+++ b/website/docs/d/is_subnet.html.markdown
@@ -79,6 +79,17 @@ In addition to all argument reference list, you can access the following attribu
 - `network_acl` - (String) The ID of the network ACL for the subnet.
 - `public_gateway` - (String) The ID of the public gateway for the subnet.
 - `resource_group` - (String) The subnet resource group.
+- `routing_table` -  (List) The routing table for this subnet. 
+  
+  Nested scheme for `routing_table`:
+  - `deleted` -  (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information.
+
+    Nested scheme for `deleted`:
+    - `more_info` -  (String) Link to documentation about deleted resources.
+  - `href` -  (String) The URL for this routing table.
+  - `id` -  (String) The unique identifier for this routing table.
+  - `name` -  (String) The user-defined name for this routing table.
+  - `resource_type` -  (String) The type of resource referenced.
 - `status` - (String) The status of the subnet.
 - `tags`  - (String) Tags associated for the instance.
 - `total_ipv4_address_count` - (Integer) The total number of IPv4 addresses.

--- a/website/docs/d/is_subnets.html.markdown
+++ b/website/docs/d/is_subnets.html.markdown
@@ -86,5 +86,14 @@ You can access the following attribute references after your data source is crea
 	- `resource_group` - (String) The resource group that the subnet belongs to.
     - `total_ipv4_address_count`- (Integer) The total number of IPv4 addresses in the subnet.
     - `status` - (String) The status of the subnet.
+  - `routing_table` -  (List) The routing table for this subnet. 
+    Nested scheme for `routing_table`:
+      - `deleted` -  (List) If present, this property indicates the referenced resource has been deleted and provides some supplementary information.
+      Nested scheme for `deleted`:
+        - `more_info` -  (String) Link to documentation about deleted resources.
+      - `href` -  (String) The URL for this routing table.
+      - `id` -  (String) The unique identifier for this routing table.
+      - `name` -  (String) The user-defined name for this routing table.
+      - `resource_type` -  (String) The type of resource referenced.
 	- `vpc` - (String) The ID of the VPC that this subnet belongs to.
 	- `zone` - (String) The zone where the subnet was created.


### PR DESCRIPTION
Community Note
Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
Relates OR Closes #0000
https://jiracloud.swg.usma.ibm.com:8443/browse/UI-22599

Output from acceptance testing:
<img width="880" alt="Screenshot 2022-06-29 at 5 36 28 PM" src="https://user-images.githubusercontent.com/78336632/176432635-1998bbf1-c4d2-4218-8a3d-36a005c2dcb9.png">

<img width="832" alt="Screenshot 2022-06-29 at 2 38 49 PM" src="https://user-images.githubusercontent.com/78336632/176432632-090f1ee7-63bf-428b-81bd-be4cc026fd47.png">

<img width="677" alt="Screenshot 2022-06-29 at 1 46 55 PM" src="https://user-images.githubusercontent.com/78336632/176432624-fa8f6114-9707-4688-ac3b-67ec46e3d69c.png">


```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSubnetDatasource_basic'

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSubnetsDataSource_basic'

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSubnetsDataSource_basic_filterRoutingTable'

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSubnetsDataSource_basic_filterResourceGroup'

```

Tested with the below template:

resource "ibm_is_vpc" "testacc_vpc" {
name = "sunitha-vpc-testing"
}

resource "ibm_is_subnet" "testacc_subnet" {
name = "sunitha-subnet-testing"
vpc = ibm_is_vpc.testacc_vpc.id
zone = "us-south-1"
ipv4_cidr_block = "10.240.0.0/24"
}
data "ibm_is_subnet" "ds_subnet" {
identifier = ibm_is_subnet.testacc_subnet.id
}

data "ibm_is_subnets" "test1" {
}

<img width="694" alt="screen1" src="https://user-images.githubusercontent.com/78336632/176380471-20babd7f-3aa9-4341-b9e9-3946c5757f91.png">
<img width="772" alt="screen2" src="https://user-images.githubusercontent.com/78336632/176380481-71736947-bf5d-4164-8876-91bd0c582042.png">


