### PR TITLE
Deprecation of `ibm_is_vpc_route` resource & correction for `vpc_routing_table_route `

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpc_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_route.go
@@ -34,12 +34,13 @@ const (
 
 func ResourceIBMISVpcRoute() *schema.Resource {
 	return &schema.Resource{
-		Create:   resourceIBMISVpcRouteCreate,
-		Read:     resourceIBMISVpcRouteRead,
-		Update:   resourceIBMISVpcRouteUpdate,
-		Delete:   resourceIBMISVpcRouteDelete,
-		Exists:   resourceIBMISVpcRouteExists,
-		Importer: &schema.ResourceImporter{},
+		DeprecationMessage: "This resource is deprecated, use ibm_is_vpc_routing_table_route instead.",
+		Create:             resourceIBMISVpcRouteCreate,
+		Read:               resourceIBMISVpcRouteRead,
+		Update:             resourceIBMISVpcRouteUpdate,
+		Delete:             resourceIBMISVpcRouteDelete,
+		Exists:             resourceIBMISVpcRouteExists,
+		Importer:           &schema.ResourceImporter{},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),

--- a/website/docs/d/is_vpc_routing_table_routes.html.markdown
+++ b/website/docs/d/is_vpc_routing_table_routes.html.markdown
@@ -47,9 +47,9 @@ Review the argument references that you can specify for your data source.
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute references after your data source is created. 
 
-- `routing_table_routes` (List) List of all the routing table in a VPC.
+- `routes` (List) List of all the routing table in a VPC.
 
-  Nested scheme for `routing_table_routes`:
+  Nested scheme for `routes`:
 	- `name` - (String) The name for the default routing table.
 	- `route_id` - (String) The unique ID for the route.
 	- `lifecycle_state` - (String) The lifecycle state of the route.

--- a/website/docs/r/is_vpc_route.html.markdown
+++ b/website/docs/r/is_vpc_route.html.markdown
@@ -7,6 +7,7 @@ description: |-
   Manages IBM IS VPC route.
 ---
 
+~>**Note**  This resource is deprecated, use `ibm_is_vpc_routing_table_route` instead.
 # ibm_is_vpc_route
 Create, update, or delete a VPC route. For more information, about VPC routes, see [setting up advanced routing in VPC](https://cloud.ibm.com/docs/vpc?topic=vpc-about-custom-routes).
 


### PR DESCRIPTION
Deprecation msg for vpc_route resource and doc, & correction in vpc_routing_table_route.

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
https://jiracloud.swg.usma.ibm.com:8443/browse/UI-23911
https://jiracloud.swg.usma.ibm.com:8443/browse/UI-23983
Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
