### PR TITLE
fix(ibm_is_security_group) : added wait logic for bm targets, wait until target is removed

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_security_group.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group.go
@@ -410,7 +410,11 @@ func resourceIBMISSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 				deleteSecurityGroupTargetBindingOptions := sess.NewDeleteSecurityGroupTargetBindingOptions(id, *securityGroupTargetReference.ID)
 				response, err = sess.DeleteSecurityGroupTargetBinding(deleteSecurityGroupTargetBindingOptions)
 				if err != nil {
-					return fmt.Errorf("[ERROR] Error deleting security group target binding while deleting security group : %s\n%s", err, response)
+					if response != nil && response.StatusCode == 404 {
+						log.Printf("[DEBUG] Security group target(%s) binding is already deleted", *securityGroupTargetReference.ID)
+					} else {
+						return fmt.Errorf("[ERROR] Error deleting security group target binding while deleting security group : %s\n%s", err, response)
+					}
 				}
 
 			}

--- a/ibm/service/vpc/resource_ibm_is_security_group.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group.go
@@ -9,11 +9,13 @@ import (
 	"log"
 	"os"
 	"reflect"
+	"time"
 
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/IBM/vpc-go-sdk/vpcv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -41,6 +43,11 @@ func ResourceIBMISSecurityGroup() *schema.Resource {
 				return flex.ResourceTagsCustomizeDiff(diff)
 			},
 		),
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
 
@@ -410,8 +417,16 @@ func resourceIBMISSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 				deleteSecurityGroupTargetBindingOptions := sess.NewDeleteSecurityGroupTargetBindingOptions(id, *securityGroupTargetReference.ID)
 				response, err = sess.DeleteSecurityGroupTargetBinding(deleteSecurityGroupTargetBindingOptions)
 				if err != nil {
-					if response != nil && response.StatusCode == 404 {
-						log.Printf("[DEBUG] Security group target(%s) binding is already deleted", *securityGroupTargetReference.ID)
+					if response != nil {
+						if response.StatusCode == 404 {
+							log.Printf("[DEBUG] Security group target(%s) binding is already deleted", *securityGroupTargetReference.ID)
+						} else if response.StatusCode == 409 {
+							log.Printf("[DEBUG] Security group target(%s) binding is in deleting, will wait till target is removed", *securityGroupTargetReference.ID)
+							_, err = isWaitForTargetDeleted(sess, id, *securityGroupTargetReference.ID, securityGroupTargetReferenceIntf, d.Timeout(schema.TimeoutDelete))
+							if err != nil {
+								return err
+							}
+						}
 					} else {
 						return fmt.Errorf("[ERROR] Error deleting security group target binding while deleting security group : %s\n%s", err, response)
 					}
@@ -425,8 +440,21 @@ func resourceIBMISSecurityGroupDelete(d *schema.ResourceData, meta interface{}) 
 		ID: &id,
 	}
 	response, err = sess.DeleteSecurityGroup(deleteSecurityGroupOptions)
+
 	if err != nil {
-		return fmt.Errorf("[ERROR] Error Deleting Security Group : %s\n%s", err, response)
+		if response != nil {
+			if response.StatusCode == 404 {
+				log.Printf("[DEBUG] Security group(%s) target bindings are already deleted", id)
+			} else if response.StatusCode == 409 {
+				log.Printf("[DEBUG] Security group(%s) has target bindings is in deleting, will wait till target is removed", id)
+				_, err = isWaitForSgCleanup(sess, id, allrecs, d.Timeout(schema.TimeoutDelete))
+				if err != nil {
+					return err
+				}
+			}
+		} else {
+			return fmt.Errorf("[ERROR] Error Deleting Security Group : %s\n%s", err, response)
+		}
 	}
 	d.SetId("")
 	return nil
@@ -497,5 +525,77 @@ func makeIBMISSecurityRuleSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+	}
+}
+
+func isWaitForTargetDeleted(client *vpcv1.VpcV1, sgId, targetId string, target vpcv1.SecurityGroupTargetReferenceIntf, timeout time.Duration) (interface{}, error) {
+	log.Printf("Waiting for Security group(%s) target(%s) to be deleted.", sgId, targetId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deleting"},
+		Target:     []string{"done", ""},
+		Refresh:    isTargetRefreshFunc(client, sgId, targetId, target),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
+	}
+
+	return stateConf.WaitForState()
+}
+
+func isTargetRefreshFunc(client *vpcv1.VpcV1, sgId, targetId string, target vpcv1.SecurityGroupTargetReferenceIntf) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		targetgetoptions := &vpcv1.GetSecurityGroupTargetOptions{
+			SecurityGroupID: &sgId,
+			ID:              &targetId,
+		}
+		sgTarget, response, err := client.GetSecurityGroupTarget(targetgetoptions)
+		if err != nil {
+			return target, "", fmt.Errorf("[ERROR] Error getting target(%s): %s\n%s", targetId, err, response)
+		}
+		if response != nil && response.StatusCode == 404 {
+			return target, "done", nil
+		}
+		return sgTarget, "deleting", nil
+	}
+}
+func isWaitForSgCleanup(client *vpcv1.VpcV1, sgId string, targets []vpcv1.SecurityGroupTargetReferenceIntf, timeout time.Duration) (interface{}, error) {
+	log.Printf("Waiting for Security group(%s) target(%s) to be deleted.", sgId, targets)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deleting"},
+		Target:     []string{"done", ""},
+		Refresh:    isSgRefreshFunc(client, sgId, targets),
+		Timeout:    timeout,
+		Delay:      10 * time.Second,
+		MinTimeout: 10 * time.Second,
+	}
+
+	return stateConf.WaitForState()
+}
+
+func isSgRefreshFunc(client *vpcv1.VpcV1, sgId string, groups []vpcv1.SecurityGroupTargetReferenceIntf) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		start := ""
+		allrecs := []vpcv1.SecurityGroupTargetReferenceIntf{}
+		for {
+			listSecurityGroupTargetsOptions := client.NewListSecurityGroupTargetsOptions(sgId)
+
+			sggroups, response, err := client.ListSecurityGroupTargets(listSecurityGroupTargetsOptions)
+			if err != nil || sggroups == nil {
+				return groups, "", fmt.Errorf("[ERROR] Error Getting Security Group Targets %s\n%s", err, response)
+			}
+			if *sggroups.TotalCount == int64(0) {
+				return groups, "done", nil
+			}
+
+			start = flex.GetNext(sggroups.Next)
+			allrecs = append(allrecs, sggroups.Targets...)
+
+			if start == "" {
+				break
+			}
+		}
+		return allrecs, "deleting", nil
 	}
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
