### PR TITLE
target_http_status_code correction

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -67,6 +67,7 @@ const (
 	isLBListenerPolicyAction                  = "action"
 	isLBListenerPolicyTargetID                = "target_id"
 	isLBListenerPolicyTargetURL               = "target_url"
+	isLBListenerPolicyTargetHTTPStatusCode    = "target_http_status_code"
 	isLBListenerPolicyHTTPSRedirectStatusCode = "target_https_redirect_status_code"
 	isLBListenerPolicyHTTPSRedirectURI        = "target_https_redirect_uri"
 	isLBListenerPolicyHTTPSRedirectListener   = "target_https_redirect_listener"
@@ -2249,10 +2250,10 @@ func ResourceLBListenerPolicyCustomizeDiff(diff *schema.ResourceDiff) error {
 			return fmt.Errorf("Load balancer listener policy: When action is forward please specify target_id")
 		}
 	} else if policyAction == "redirect" {
-		_, httpsStatusCodeSet := diff.GetOk(isLBListenerPolicyHTTPSRedirectStatusCode)
+		_, httpsStatusCodeSet := diff.GetOk(isLBListenerPolicyTargetHTTPStatusCode)
 		_, targetURLSet := diff.GetOk(isLBListenerPolicyTargetURL)
 
-		if !httpsStatusCodeSet && diff.NewValueKnown(isLBListenerPolicyHTTPSRedirectStatusCode) {
+		if !httpsStatusCodeSet && diff.NewValueKnown(isLBListenerPolicyTargetHTTPStatusCode) {
 			return fmt.Errorf("Load balancer listener policy: When action is redirect please specify target_http_status_code")
 		}
 

--- a/website/docs/r/is_lb_listener_policy.html.markdown
+++ b/website/docs/r/is_lb_listener_policy.html.markdown
@@ -68,10 +68,11 @@ resource "ibm_is_lb_listener" "example" {
 }
 resource "ibm_is_lb_listener_policy" "example" {
   lb                                = ibm_is_lb.example.id
+  listener                          = ibm_is_lb_listener.example.listener_id
   action                            = "https_redirect"
   priority                          = 2
   name                              = "example-listener"
-  taget_https_redirect_listener     = ibm_is_lb_listener.example.listener_id
+  target_https_redirect_listener    = ibm_is_lb_listener.example.listener_id
   target_https_redirect_status_code = 301
   target_https_redirect_uri         = "/example?doc=geta"
   rules {


### PR DESCRIPTION

<img width="964" alt="Screenshot 2022-08-24 at 7 50 17 PM" src="https://user-images.githubusercontent.com/78336632/186576589-ede0c7c6-e2f0-481e-b4b6-3288473d086b.png">

<img width="663" alt="Screenshot 2022-08-25 at 10 12 29 AM" src="https://user-images.githubusercontent.com/78336632/186576623-21a4f340-9f75-4276-8892-0029ca049cff.png">

```
# terraform {
#   required_providers {
#     ibm = {
#       source  = "ibm-cloud/ibm"
#       version = ">= 1.44.1"
#     }
#     random = {
#       source  = "hashicorp/random"
#       version = "3.0.1"
#     }
#   }
# }
# provider "ibm" {
#   region = "us-south"
# }
resource "ibm_is_vpc" "example" {
  name = "example-vpc"
}
resource "ibm_is_vpc_routing_table" "example" {
  name = "example-routing-table"
  vpc  = ibm_is_vpc.example.id
}
resource "ibm_is_subnet" "example" {
  name            = "example-subnet"
  vpc             = ibm_is_vpc.example.id
  zone            = "us-south-1"
  ipv4_cidr_block = "10.240.0.0/24"
  routing_table   = ibm_is_vpc_routing_table.example.routing_table
  //User can configure timeouts
  timeouts {
    create = "90m"
    delete = "30m"
  }
}
resource "ibm_is_lb" "example" {
  name    = "example-lb"
  subnets = [ibm_is_subnet.example.id]
}
resource "ibm_is_lb_listener" "example" {
  lb                   = ibm_is_lb.example.id
  port                 = "9086"
  protocol             = "https"
  certificate_instance = "crn:v1:staging:public:cloudcerts:us-south:a2d1bace7b46e4815a81e52c6ffeba5cf:af925157-b125-4db2-b642-adacb8b9c7f5:certificate:c81627a1bf6f766379cc4b98fd2a44ed"
}
// Action- "https_redirect"
resource "ibm_is_lb_listener_policy" "example" {
  lb                      = ibm_is_lb.example.id
  listener                = ibm_is_lb_listener.example.listener_id
  action                  = "redirect"
  priority                = 2
  name                    = "example-listener-policy"
  target_http_status_code = 302
  # target_https_redirect_status_code = 302
  target_url              = "https://www.redirect.com"
  rules {
    condition = "contains"
    type      = "header"
    field     = "1"
    value     = "2"
  }
}
```