### PR TITLE
enhancement(bare_metal_server): added support for bare metal server nic ip datasource(s)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,10 +25,10 @@ require (
 	github.com/IBM/platform-services-go-sdk v0.28.2
 	github.com/IBM/push-notifications-go-sdk v0.0.0-20210310100607-5790b96c47f5
 	github.com/IBM/scc-go-sdk/v3 v3.1.6
-	github.com/IBM/scc-go-sdk/v4 v4.0.0 // indirect
+	github.com/IBM/scc-go-sdk/v4 v4.0.0
 	github.com/IBM/schematics-go-sdk v0.2.1
 	github.com/IBM/secrets-manager-go-sdk v0.1.19
-	github.com/IBM/vpc-go-sdk v0.23.0
+	github.com/IBM/vpc-go-sdk v0.24.0
 	github.com/PromonLogicalis/asn1 v0.0.0-20190312173541-d60463189a56 // indirect
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 	github.com/Shopify/sarama v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -70,10 +70,8 @@ github.com/IBM/schematics-go-sdk v0.2.1 h1:byATysGD+Z1k/wdtNqQmKALcAPjgSLuSyzcab
 github.com/IBM/schematics-go-sdk v0.2.1/go.mod h1:Tw2OSAPdpC69AxcwoyqcYYaGTTW6YpERF9uNEU+BFRQ=
 github.com/IBM/secrets-manager-go-sdk v0.1.19 h1:0GPs5EoTaWNsjo4QPj64GNxlWfN8VHJy4RDFLqddSe8=
 github.com/IBM/secrets-manager-go-sdk v0.1.19/go.mod h1:eO3dBhzPrHkkt+yPex/jB2xD6qHZxBko+Aw+0tfqHeA=
-github.com/IBM/vpc-go-sdk v0.22.0 h1:jo2WMfiFXhAyJkdJeCVHwvT6kgTg2tg8sDeP9zrMFVg=
-github.com/IBM/vpc-go-sdk v0.22.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
-github.com/IBM/vpc-go-sdk v0.23.0 h1:C26g02pPtTEWyLHNKK0mlFdpHeb9+noku9Q6qJLmdkc=
-github.com/IBM/vpc-go-sdk v0.23.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
+github.com/IBM/vpc-go-sdk v0.24.0 h1:YelLUm9eo6NchQmPmUrg6I1p2tamR1FxcvZp6aHtJzE=
+github.com/IBM/vpc-go-sdk v0.24.0/go.mod h1:YPyIfI+/qhPqlYp+I7dyx2U1GLcXgp/jzVvsZfUH4y8=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56 h1:vuquMR410psHNax14XKNWa0Ae/kYgWJcXi0IFuX60N0=
 github.com/Logicalis/asn1 v0.0.0-20190312173541-d60463189a56/go.mod h1:Zb3OT4l0mf7P/GOs2w2Ilj5sdm5Whoq3pa24dAEBHFc=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/ibm/provider/provider.go
+++ b/ibm/provider/provider.go
@@ -369,6 +369,8 @@ func Provider() *schema.Provider {
 			"ibm_is_bare_metal_server_initialization":                 vpc.DataSourceIBMIsBareMetalServerInitialization(),
 			"ibm_is_bare_metal_server_network_interface_floating_ip":  vpc.DataSourceIBMIsBareMetalServerNetworkInterfaceFloatingIP(),
 			"ibm_is_bare_metal_server_network_interface_floating_ips": vpc.DataSourceIBMIsBareMetalServerNetworkInterfaceFloatingIPs(),
+			"ibm_is_bare_metal_server_network_interface_reserved_ip":  vpc.DataSourceIBMISBareMetalServerNICReservedIP(),
+			"ibm_is_bare_metal_server_network_interface_reserved_ips": vpc.DataSourceIBMISBareMetalServerNICReservedIPs(),
 			"ibm_is_bare_metal_server_network_interface":              vpc.DataSourceIBMIsBareMetalServerNetworkInterface(),
 			"ibm_is_bare_metal_server_network_interfaces":             vpc.DataSourceIBMIsBareMetalServerNetworkInterfaces(),
 			"ibm_is_bare_metal_server_profile":                        vpc.DataSourceIBMIsBareMetalServerProfile(),

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ip.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ip.go
@@ -1,0 +1,138 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Define all the constants that matches with the given terrafrom attribute
+const (
+	// Response Param Constants
+
+	isBareMetalServerNICReservedIPCreatedAt      = "created_at"
+	isBareMetalServerNICReservedIPhref           = "href"
+	isBareMetalServerNICReservedIPLifecycleState = "lifecycle_state"
+	isBareMetalServerNICReservedIPOwner          = "owner"
+	isBareMetalServerNICReservedIPType           = "resource_type"
+	isBareMetalServerNICReservedIPTarget         = "target"
+)
+
+func DataSourceIBMISBareMetalServerNICReservedIP() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMISBareMetalServerNICReservedIPRead,
+		Schema: map[string]*schema.Schema{
+			/*
+				Request Parameters
+				==================
+				These are mandatory req parameters
+			*/
+			isBareMetalServerID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The Bare Metal Server identifier.",
+			},
+			isBareMetalServerNicID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The Bare Metal Server network interface identifier.",
+			},
+			isBareMetalServerNicIpID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The reserved IP identifier.",
+			},
+
+			/*
+				Response Parameters
+				===================
+				All of these are computed and an user doesn't need to provide
+				these from outside.
+			*/
+
+			isBareMetalServerNicIpAddress: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The IP address",
+			},
+			isBareMetalServerNicIpAutoDelete: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If set to true, this reserved IP will be automatically deleted",
+			},
+			isBareMetalServerNICReservedIPCreatedAt: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The date and time that the reserved IP was created.",
+			},
+			isBareMetalServerNICReservedIPhref: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The URL for this reserved IP.",
+			},
+			isBareMetalServerNicIpName: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The user-defined or system-provided name for this reserved IP.",
+			},
+			isBareMetalServerNICReservedIPOwner: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The owner of a reserved IP, defining whether it is managed by the user or the provider.",
+			},
+			isBareMetalServerNICReservedIPType: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The resource type.",
+			},
+			isBareMetalServerNICReservedIPTarget: {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Reserved IP target id.",
+			},
+		},
+	}
+}
+
+// dataSourceIBMISBareMetalServerNICReservedIPRead is used when the reserved IPs are read from the vpc
+func dataSourceIBMISBareMetalServerNICReservedIPRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	sess, err := meta.(conns.ClientSession).VpcV1API()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	bareMetalServer := d.Get(isBareMetalServerID).(string)
+	bareMetalServerNICId := d.Get(isBareMetalServerNicID).(string)
+	reservedIPID := d.Get(isBareMetalServerNicIpID).(string)
+
+	options := sess.NewGetBareMetalServerNetworkInterfaceIPOptions(bareMetalServer, bareMetalServerNICId, reservedIPID)
+	reserveIP, response, err := sess.GetBareMetalServerNetworkInterfaceIPWithContext(context, options)
+
+	if err != nil || response == nil || reserveIP == nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error fetching the reserved IP %s\n%s", err, response))
+	}
+
+	d.SetId(*reserveIP.ID)
+	d.Set(isBareMetalServerNicIpAutoDelete, *reserveIP.AutoDelete)
+	d.Set(isBareMetalServerNICReservedIPCreatedAt, (*reserveIP.CreatedAt).String())
+	d.Set(isBareMetalServerNICReservedIPhref, *reserveIP.Href)
+	d.Set(isBareMetalServerNicIpName, *reserveIP.Name)
+	d.Set(isBareMetalServerNICReservedIPOwner, *reserveIP.Owner)
+	d.Set(isBareMetalServerNICReservedIPType, *reserveIP.ResourceType)
+	d.Set(isBareMetalServerNicIpAddress, *reserveIP.Address)
+	if reserveIP.Target != nil {
+		target, ok := reserveIP.Target.(*vpcv1.ReservedIPTarget)
+		if ok {
+			d.Set(isBareMetalServerNICReservedIPTarget, target.ID)
+		}
+	}
+	return nil // By default there should be no error
+}

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ip_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ip_test.go
@@ -1,0 +1,58 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+package vpc_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMISBareMetalServerNICReservedIP_basic(t *testing.T) {
+	resName := "data.ibm_is_bare_metal_server_network_interface_reserved_ip.test1"
+	var server string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-sshname-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIBMISBareMetalServerNICReservedIPdataSoruceConfig(vpcname, subnetname, sshname, publicKey, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttrSet(resName, "name"),
+					resource.TestCheckResourceAttrSet(resName, "address"),
+					resource.TestCheckResourceAttrSet(resName, "auto_delete"),
+					resource.TestCheckResourceAttrSet(resName, "created_at"),
+					resource.TestCheckResourceAttrSet(resName, "href"),
+					resource.TestCheckResourceAttrSet(resName, "owner"),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ip"),
+					resource.TestCheckResourceAttrSet(resName, "resource_type"),
+					resource.TestCheckResourceAttrSet(resName, "target"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIBMISBareMetalServerNICReservedIPdataSoruceConfig(vpcname, subnetname, sshname, publicKey, name string) string {
+	// status filter defaults to empty
+
+	return testAccCheckIBMISBareMetalServerConfig(vpcname, subnetname, sshname, publicKey, name) +
+		fmt.Sprintf(`
+      data "ibm_is_bare_metal_server_network_interface_reserved_ip" "test1" {
+		  bare_metal_server =  ibm_is_bare_metal_server.testacc_bms.id
+		  network_interface =  ibm_is_bare_metal_server.testacc_bms.primary_network_interface.0.id
+		  reserved_ip 		=  ibm_is_bare_metal_server.testacc_bms.primary_network_interface.0.primary_ip.0.reserved_ip
+      }`)
+}

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ips.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ips.go
@@ -1,0 +1,162 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// Define all the constants that matches with the given terrafrom attribute
+const (
+	// Request Param Constants
+	isBareMetalServerNICReservedIPLimit  = "limit"
+	isBareMetalServerNICReservedIPSort   = "sort"
+	isBareMetalServerNICReservedIPs      = "reserved_ips"
+	isBareMetalServerNICReservedIPsCount = "total_count"
+)
+
+func DataSourceIBMISBareMetalServerNICReservedIPs() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceIBMISBareMetalServerNICReservedIPsRead,
+		Schema: map[string]*schema.Schema{
+			/*
+				Request Parameters
+				==================
+				These are mandatory req parameters
+			*/
+			isBareMetalServerID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The BareMetalServer identifier.",
+			},
+			isBareMetalServerNicID: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The BareMetalServer network interface identifier.",
+			},
+			/*
+				Response Parameters
+				===================
+				All of these are computed and an user doesn't need to provide
+				these from outside.
+			*/
+
+			isBareMetalServerNICReservedIPs: {
+				Type:        schema.TypeList,
+				Description: "Collection of all reserved IPs bound to a network interface.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						isBareMetalServerNicIpAddress: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The IP address",
+						},
+						isBareMetalServerNicIpAutoDelete: {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "If reserved ip shall be deleted automatically",
+						},
+						isBareMetalServerNICReservedIPCreatedAt: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The date and time that the reserved IP was created.",
+						},
+						isBareMetalServerNICReservedIPhref: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The URL for this reserved IP.",
+						},
+						isBareMetalServerNicIpID: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The unique identifier for this reserved IP",
+						},
+						isBareMetalServerNicIpName: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The user-defined or system-provided name for this reserved IP.",
+						},
+						isBareMetalServerNICReservedIPOwner: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The owner of a reserved IP, defining whether it is managed by the user or the provider.",
+						},
+						isBareMetalServerNICReservedIPType: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The resource type.",
+						},
+						isBareMetalServerNICReservedIPTarget: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Reserved IP target id",
+						},
+					},
+				},
+			},
+			isBareMetalServerNICReservedIPsCount: {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The total number of resources across all pages",
+			},
+		},
+	}
+}
+
+func dataSourceIBMISBareMetalServerNICReservedIPsRead(context context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	sess, err := meta.(conns.ClientSession).VpcV1API()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	bareMetalServerID := d.Get(isBareMetalServerID).(string)
+	nicID := d.Get(isBareMetalServerNicID).(string)
+
+	// Flatten all the reserved IPs
+	allrecs := []vpcv1.ReservedIP{}
+	options := &vpcv1.ListBareMetalServerNetworkInterfaceIpsOptions{
+		BareMetalServerID:  &bareMetalServerID,
+		NetworkInterfaceID: &nicID,
+	}
+
+	result, response, err := sess.ListBareMetalServerNetworkInterfaceIpsWithContext(context, options)
+	if err != nil || response == nil || result == nil {
+		return diag.FromErr(fmt.Errorf("[ERROR] Error fetching reserved ips %s\n%s", err, response))
+	}
+	allrecs = append(allrecs, result.Ips...)
+
+	// Now store all the reserved IP info with their response tags
+	reservedIPs := []map[string]interface{}{}
+	for _, data := range allrecs {
+		ipsOutput := map[string]interface{}{}
+		ipsOutput[isBareMetalServerNicIpAddress] = *data.Address
+		ipsOutput[isBareMetalServerNicIpAutoDelete] = *data.AutoDelete
+		ipsOutput[isBareMetalServerNICReservedIPCreatedAt] = (*data.CreatedAt).String()
+		ipsOutput[isBareMetalServerNICReservedIPhref] = *data.Href
+		ipsOutput[isBareMetalServerNicIpID] = *data.ID
+		ipsOutput[isBareMetalServerNicIpName] = *data.Name
+		ipsOutput[isBareMetalServerNICReservedIPOwner] = *data.Owner
+		ipsOutput[isBareMetalServerNICReservedIPType] = *data.ResourceType
+		target, ok := data.Target.(*vpcv1.ReservedIPTarget)
+		if ok {
+			ipsOutput[isReservedIPTarget] = target.ID
+		}
+		reservedIPs = append(reservedIPs, ipsOutput)
+	}
+
+	d.SetId(time.Now().UTC().String()) // This is not any reserved ip or BareMetalServer id but state id
+	d.Set(isBareMetalServerNICReservedIPs, reservedIPs)
+	d.Set(isBareMetalServerNICReservedIPsCount, len(reservedIPs))
+	d.Set(isBareMetalServerID, bareMetalServerID)
+	d.Set(isBareMetalServerNicID, nicID)
+	return nil
+}

--- a/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ips_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_bare_metal_server_network_interface_reserved_ips_test.go
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. 2017, 2021 All Rights Reserved.
+// Licensed under the Mozilla Public License v2.0
+
+package vpc_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	acc "github.com/IBM-Cloud/terraform-provider-ibm/ibm/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIBMISBareMetalServerNICReservedIPs_basic(t *testing.T) {
+	resName := "data.ibm_is_bare_metal_server_network_interface_reserved_ips.test1"
+	var server string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-server-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tfip-subnet-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-sshname-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIBMISBareMetalServerNICReservedIPSResoruceConfig(vpcname, subnetname, sshname, publicKey, name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISBareMetalServerExists("ibm_is_bare_metal_server.testacc_bms", server),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ips.0.name"),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ips.0.address"),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ips.0.auto_delete"),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ips.0.created_at"),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ips.0.href"),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ips.0.resource_type"),
+					resource.TestCheckResourceAttrSet(resName, "reserved_ips.0.target"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIBMISBareMetalServerNICReservedIPSResoruceConfig(vpcname, subnetname, sshname, publicKey, name string) string {
+	// status filter defaults to empty
+	return testAccCheckIBMISBareMetalServerConfig(vpcname, subnetname, sshname, publicKey, name) +
+		fmt.Sprintf(`
+	data "ibm_is_bare_metal_server_network_interface_reserved_ips" "test1" {
+		bare_metal_server	 	=  	ibm_is_bare_metal_server.testacc_bms.id
+		  network_interface 	=  	ibm_is_bare_metal_server.testacc_bms.primary_network_interface.0.id
+	}`)
+}

--- a/website/docs/d/is_bare_metal_server_network_interface_reserved_ip.html.markdown
+++ b/website/docs/d/is_bare_metal_server_network_interface_reserved_ip.html.markdown
@@ -1,0 +1,44 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : reserved_ip"
+description: |-
+  Shows the info for a reserved IP and bare metal server network interface.
+---
+
+# ibm\_is_bare_metal_server_network_interface_reserved_ip
+
+Import the details of an existing Reserved IP in a network interface of an bare metal server as a read-only data source. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```terraform
+data "ibm_is_bare_metal_server_network_interface_reserved_ip" "data_reserved_ip" {
+  bare_metal_server = ibm_is_bare_metal_server.test_bare_metal_server.id
+  network_interface = ibm_is_bare_metal_server.test_bare_metal_server.network_interfaces.0.id
+  reserved_ip = ibm_is_bare_metal_server.test_bare_metal_server.network_interfaces.0.ips.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported as inputs/request params:
+
+- `bare_metal_server` - (Required, string) The id for the bare metal server.
+- `network_interface` - (Required, string) The id for the network interface.
+- `reserved_ip` - (Required, string) The id for the Reserved IP.
+
+
+## Attribute Reference
+
+The following attributes are exported as output/response:
+
+- `auto_delete` - (String) The auto_delete boolean for reserved IP
+- `created_at` - (String) The creation timestamp for the reserved IP
+- `href` - (String) The unique reference for the reserved IP
+- `id` - (String) The id for the reserved IP
+- `name` - (String) The name for the reserved IP
+- `owner` - (String) The owner of the reserved IP
+- `reserved_ip` - (String) Same as `id`
+- `resource_type` - (String) The type of resource
+- `target` - (String) The id for the target for the reserved IP

--- a/website/docs/d/is_bare_metal_server_network_interface_reserved_ips.html.markdown
+++ b/website/docs/d/is_bare_metal_server_network_interface_reserved_ips.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "VPC infrastructure"
+layout: "ibm"
+page_title: "IBM : reserved_ips"
+description: |-
+  Lists all the info in reserved IP for Bare Metal Server network interface.
+---
+
+# ibm\_is_bare_metal_server_network_interface_reserved_ips
+
+Import the details of all the Reserved IPs in a network interface of an bare metal server as a read-only data source. You can then reference the fields of the data source in other resources within the same configuration using interpolation syntax.
+
+## Example Usage
+
+```terraform
+data "ibm_is_bare_metal_server_network_interface_reserved_ips" "data_reserved_ips" {
+  bare_metal_server = ibm_is_bare_metal_server.test_bare_metal_server.id
+  network_interface = ibm_is_bare_metal_server.test_bare_metal_server.network_interfaces.0.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported as inputs/request params:
+
+* `bare_metal_server` - (Required, string) The id for the bare metal server.
+* `network_interface` - (Required, string) The id for the network interface.
+
+
+## Attribute Reference
+
+The following attributes are exported as output/response:
+
+- `id` - The id for the all the reserved ID (current timestamp)
+- `reserved_ips` - The collection of all the reserved IPs in the network interface
+   - `address` - (String) The IP bound for the reserved IP
+   - `auto_delete` - (Bool) If reserved ip shall be deleted automatically
+   - `created_at` - (String) The date and time that the reserved IP was created
+   - `href` - (String) The URL for this reserved IP
+   - `reserved_ip` - (String) The unique identifier for this reserved IP
+   - `name` - (String) The user-defined or system-provided name for this reserved IP
+   - `owner` -(String)  The owner of a reserved IP, defining whether it is managed by the user or the provider
+   - `resource_type` - (String) The resource type
+   - `target` - (String) The id for the target for the reserved IP.
+
+- `total_count` - The number of reserved IP in the network interface of the bare metal server


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
--- PASS: TestAccIBMISBareMetalServerNICReservedIPs_basic (24.93s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     26.748s
```
```
--- PASS: TestAccIBMISBareMetalServerNICReservedIP_basic (25.82s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     27.827s
```

