### PR TITLE
fix(doc): fixed documentation on deprecation of primary_ipv4_address on is_instance

### DIFF
--- a/website/docs/d/is_instance.html.markdown
+++ b/website/docs/d/is_instance.html.markdown
@@ -129,7 +129,7 @@ In addition to all argument reference list, you can access the following attribu
   - `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
 
       Nested scheme for `primary_ip`:
-      - `address` - (String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+      - `address` - (String) The IP address of the reserved IP. Same as `network_interfaces.[].primary_ipv4_address`
       - `href`- (String) The URL for this reserved IP
       - `name`- (String) The user-defined or system-provided name for this reserved IP
       - `reserved_ip`- (String) The unique identifier for this reserved IP
@@ -156,7 +156,7 @@ In addition to all argument reference list, you can access the following attribu
   - `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
   
       Nested scheme for `primary_ip`:
-      - `address` - (String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+      - `address` - (String) The IP address of the reserved IP. Same as `primary_ipv4_address`
       - `href`- (String) The URL for this reserved IP
       - `name`- (String) The user-defined or system-provided name for this reserved IP
       - `reserved_ip`- (String) The unique identifier for this reserved IP

--- a/website/docs/d/is_instance_network_interface.html.markdown
+++ b/website/docs/d/is_instance_network_interface.html.markdown
@@ -108,7 +108,7 @@ In addition to all arguments above, the following attributes are exported:
 - `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
 
     Nested scheme for `primary_ip`:
-    - `address` - (String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+    - `address` - (String) The IP address of the reserved IP. Same as `primary_ipv4_address`
     - `href`- (String) The URL for this reserved IP
     - `name`- (String) The user-defined or system-provided name for this reserved IP
     - `reserved_ip`- (String) The unique identifier for this reserved IP

--- a/website/docs/d/is_instance_network_interfaces.html.markdown
+++ b/website/docs/d/is_instance_network_interfaces.html.markdown
@@ -96,7 +96,7 @@ In addition to all argument references listed, you can access the following attr
 	- `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
 
 		Nested scheme for `primary_ip`:
-		- `address` - (String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+		- `address` - (String) The IP address of the reserved IP. Same as `primary_ipv4_address`
 		- `href`- (String) The URL for this reserved IP
 		- `name`- (String) The user-defined or system-provided name for this reserved IP
 		- `reserved_ip`- (String) The unique identifier for this reserved IP

--- a/website/docs/d/is_instances.html.markdown
+++ b/website/docs/d/is_instances.html.markdown
@@ -96,7 +96,7 @@ In addition to all argument reference list, you can access the following attribu
 		- `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
 
 			Nested scheme for `primary_ip`:
-			- `address` - (String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+			- `address` - (String) The IP address of the reserved IP. Same as `primary_ipv4_address`
 			- `href`- (String) The URL for this reserved IP
 			- `name`- (String) The user-defined or system-provided name for this reserved IP
 			- `reserved_ip`- (String) The unique identifier for this reserved IP
@@ -124,7 +124,7 @@ In addition to all argument reference list, you can access the following attribu
 		- `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
 
 			Nested scheme for `primary_ip`:
-			- `address` - (String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+			- `address` - (String) The IP address of the reserved IP. Same as `primary_ipv4_address`
 			- `href`- (String) The URL for this reserved IP
 			- `name`- (String) The user-defined or system-provided name for this reserved IP
 			- `reserved_ip`- (String) The unique identifier for this reserved IP

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -55,7 +55,7 @@ resource "ibm_is_instance" "example" {
 
   primary_network_interface {
     subnet = ibm_is_subnet.example.id
-    primary_ipv4_address = "10.240.0.6"
+    primary_ipv4_address = "10.240.0.6"  // will be deprecated. Use primary_ip.[0].address
     allow_ip_spoofing = true
   }
 
@@ -76,13 +76,17 @@ resource "ibm_is_instance" "example" {
     delete = "15m"
   }
 }
+```
+### Sample for creating an instance with reserved ip as primary_ip reference.
 
+The following example shows how you can create a virtual server instance using reserved ip as the primary ip reference of the network interface
 
-// Example to provision instance using subnet reserved ip
+// Example to provision instance using reserved ip
 
+```
 resource "ibm_is_subnet_reserved_ip" "example" {
-  subnet = ibm_is_subnet.example.id
-  name = "example-reserved-ip1"
+  subnet    = ibm_is_subnet.example.id
+  name      = "example-reserved-ip1"
   address		= "${replace(ibm_is_subnet.example.ipv4_cidr_block, "0/24", "13")}"
 }
 
@@ -353,12 +357,13 @@ Review the argument references that you can specify for your resource.
 
   - `name` - (Optional, String) The name of the network interface.
   - `primary_ip` - (Optional, List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
+
       Nested scheme for `primary_ip`:
       - `auto_delete` - (Optional, Bool) Indicates whether this reserved IP member will be automatically deleted when either target is deleted, or the reserved IP is unbound.
-      - `address` - (Optional, String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+      - `address` - (Optional, String) The IP address of the reserved IP. This is same as `network_interfaces.[].primary_ipv4_address`
       - `name`- (Optional, String) The user-defined or system-provided name for this reserved IP
-      - `reserved_ip`- (Optional, String) The unique identifier for this reserved IP
-  - `primary_ipv4_address` - (Optional, Deprecated, Forces new resource, String) The IPV4 address of the interface. `primary_ipv4_address` is depreated, use `primary_ip` instead.
+      - `reserved_ip`- (Optional, String) The unique identifier for this reserved IP.
+  - `primary_ipv4_address` - (Optional, Deprecated, Forces new resource, String) The IPV4 address of the interface. `primary_ipv4_address` will be deprecated, use `primary_ip.[0].address` instead.
   - `subnet` - (Required, String) The ID of the subnet.
   - `security_groups`- (Optional, List of strings)A comma separated list of security groups to add to the primary network interface.
 - `placement_group` - (Optional, string) Unique Identifier of the Placement Group for restricting the placement of the instance
@@ -373,12 +378,13 @@ Review the argument references that you can specify for your resource.
   - `name` - (Optional, String) The name of the network interface.
   - `port_speed` - (Deprecated, Integer) Speed of the network interface.
   - `primary_ip` - (Optional, List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
-    Nested scheme for `primary_ip`:
-    - `auto_delete` - (Optional, Bool) Indicates whether this reserved IP member will be automatically deleted when either target is deleted, or the reserved IP is unbound.
-    - `address` - (Optional, String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
-    - `name`- (Optional, String) The user-defined or system-provided name for this reserved IP
-    - `reserved_ip`- (Optional, String) The unique identifier for this reserved IP
-  - `primary_ipv4_address` - (Optional, Deprecated, Forces new resource, String) The IPV4 address of the interface.`primary_ipv4_address` is depreated, use `primary_ip` instead.
+
+      Nested scheme for `primary_ip`:
+      - `auto_delete` - (Optional, Bool) Indicates whether this reserved IP member will be automatically deleted when either target is deleted, or the reserved IP is unbound.
+      - `address` - (Optional, String) The IP address of the reserved IP. This is same as `primary_network_interface.[0].primary_ipv4_address` which will be deprecated.
+      - `name`- (Optional, String) The user-defined or system-provided name for this reserved IP
+      - `reserved_ip`- (Optional, String) The unique identifier for this reserved IP
+  - `primary_ipv4_address` - (Optional, Deprecated, Forces new resource, String) The IPV4 address of the interface.`primary_ipv4_address` will be deprecated, use `primary_ip.[0].address` instead.
   - `subnet` - (Required, String) The ID of the subnet.
   - `security_groups`-List of strings-Optional-A comma separated list of security groups to add to the primary network interface.
 - `profile` - (Required, String) The name of the profile that you want to use for your instance. Not required when using `instance_template`. To list supported profiles, run `ibmcloud is instance-profiles` or `ibm_is_instance_profiles` datasource.
@@ -450,7 +456,14 @@ In addition to all argument reference list, you can access the following attribu
   - `name` - (String) The name of the network interface.
   - `subnet` - (String) The ID of the subnet.
   - `security_groups`- (List of Strings) A list of security groups that are used in the network interface.
-  - `primary_ipv4_address` - (String) The primary IPv4 address.
+  - `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
+
+      Nested scheme for `primary_ip`:
+      - `auto_delete` - (Bool) Indicates whether this reserved IP member will be automatically deleted when either target is deleted, or the reserved IP is unbound.
+      - `address` - (String) The IP address of the reserved IP. This is same as `network_interfaces.[].primary_ipv4_address` which will be deprecated.
+      - `name`- (String) The user-defined or system-provided name for this reserved IP
+      - `reserved_ip`- (String) The unique identifier for this reserved IP
+  - `primary_ipv4_address` - (String) The primary IPv4 address. Same as `primary_ip.[0].address`
 - `primary_network_interface`- (List of Strings) A list of primary network interfaces that are attached to the instance.
 
   Nested scheme for `primary_network_interface`:
@@ -459,7 +472,14 @@ In addition to all argument reference list, you can access the following attribu
   - `name` - (String) The name of the primary network interface.
   - `subnet` - (String) The ID of the subnet that the primary network interface is attached to.
   - `security_groups`-List of strings-A list of security groups that are used in the primary network interface.
-  - `primary_ipv4_address` - (String) The primary IPv4 address.
+  - `primary_ip` - (List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
+
+      Nested scheme for `primary_ip`:
+      - `auto_delete` - (Bool) Indicates whether this reserved IP member will be automatically deleted when either target is deleted, or the reserved IP is unbound.
+      - `address` - (String) The IP address of the reserved IP. This is same as `primary_network_interface.[0].primary_ipv4_address` which will be deprecated.
+      - `name`- (String) The user-defined or system-provided name for this reserved IP
+      - `reserved_ip`- (String) The unique identifier for this reserved IP.
+  - `primary_ipv4_address` - (String) The primary IPv4 address. Same as `primary_ip.[0].address`
 - `status` - (String) The status of the instance.
 - `status_reasons` - (List) Array of reasons for the current status.
 

--- a/website/docs/r/is_instance_network_interface.html.markdown
+++ b/website/docs/r/is_instance_network_interface.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 - `primary_ip` - (Optional, List) The primary IP address to bind to the network interface. This can be specified using an existing reserved IP, or a prototype object for a new reserved IP.
     Nested scheme for `primary_ip`:
     - `auto_delete` - (Optional, Bool) Indicates whether this reserved IP member will be automatically deleted when either target is deleted, or the reserved IP is unbound.
-    - `address` - (Optional, String) The IP address. If the address has not yet been selected, the value will be 0.0.0.0. This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+    - `address` - (Optional, String) The IP address. Same as `primary_ipv4_address`
     - `name`- (Optional, String) The user-defined or system-provided name for this reserved IP
     - `reserved_ip`- (Optional, String) The unique identifier for this reserved IP
 - `primary_ipv4_address` - (Optional, Forces new resource, String) The primary IPv4 address. If specified, it must be an available address on the network interface's subnet. If unspecified, an available address on the subnet will be automatically selected.


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
