### PR TITLE
fix(bare_metal_server_network_interface_allow_float) : reordered the wait logic in bare metal nics

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
+++ b/ibm/service/vpc/resource_ibm_is_bare_metal_server_network_interface_allow_float_test.go
@@ -53,6 +53,12 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "enable_infrastructure_nat", "true"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "name", "eth21"),
+					resource.TestCheckResourceAttrWith("ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "primary_ip.0.address", func(v string) error {
+						if v == "0.0.0.0" {
+							return fmt.Errorf("Attribute 'address' %s is not updated", v)
+						}
+						return nil
+					}),
 				),
 			},
 		},
@@ -87,6 +93,12 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "allow_interface_to_float", "true"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "enable_infrastructure_nat", "false"),
+					resource.TestCheckResourceAttrWith("ibm_is_bare_metal_server_network_interface_allow_float.bms_nic", "primary_ip.0.address", func(v string) error {
+						if v == "0.0.0.0" {
+							return fmt.Errorf("Attribute 'address' %s is not updated", v)
+						}
+						return nil
+					}),
 				),
 			},
 		},


### PR DESCRIPTION
…

<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
