### PR TITLE
Remove deprecated ciphers

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_ike_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_ike_policy.go
@@ -145,9 +145,9 @@ func ResourceIBMISIKEPolicy() *schema.Resource {
 func ResourceIBMISIKEValidator() *validate.ResourceValidator {
 
 	validateSchema := make([]validate.ValidateSchema, 0)
-	authentication_algorithm := "md5, sha1, sha256, sha512, sha384"
-	encryption_algorithm := "triple_des, aes128, aes192, aes256"
-	dh_group := "2, 5, 14, 19, 15, 16, 17, 18, 20, 21, 22, 23, 24, 31"
+	authentication_algorithm := "sha256, sha512, sha384"
+	encryption_algorithm := "aes128, aes192, aes256"
+	dh_group := "14, 19, 15, 16, 17, 18, 20, 21, 22, 23, 24, 31"
 	ike_version := "1, 2"
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{

--- a/ibm/service/vpc/resource_ibm_is_ike_policy_test.go
+++ b/ibm/service/vpc/resource_ibm_is_ike_policy_test.go
@@ -30,11 +30,11 @@ func TestAccIBMISIKEPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_is_ike_policy.example", "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "authentication_algorithm", "md5"),
+						"ibm_is_ike_policy.example", "authentication_algorithm", "sha256"),
 					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "encryption_algorithm", "triple_des"),
+						"ibm_is_ike_policy.example", "encryption_algorithm", "aes128"),
 					resource.TestCheckResourceAttr(
-						"ibm_is_ike_policy.example", "dh_group", "2"),
+						"ibm_is_ike_policy.example", "dh_group", "14"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_ike_policy.example", "ike_version", "1"),
 				),
@@ -107,9 +107,9 @@ func testAccCheckIBMISIKEPolicyConfig(name string) string {
 	return fmt.Sprintf(`
 		resource "ibm_is_ike_policy" "example" {
 			name = "%s"
-			authentication_algorithm = "md5"
-			encryption_algorithm = "triple_des"
-			dh_group = 2
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
+			dh_group = 14
 			ike_version = 1
 		}
 	`, name)

--- a/ibm/service/vpc/resource_ibm_is_ipsec_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_ipsec_policy.go
@@ -153,8 +153,8 @@ func ResourceIBMISIPSecPolicy() *schema.Resource {
 func ResourceIBMISIPSECValidator() *validate.ResourceValidator {
 
 	validateSchema := make([]validate.ValidateSchema, 0)
-	authentication_algorithm := "md5, sha1, sha256, sha512, sha384, disabled"
-	encryption_algorithm := "triple_des, aes128, aes256, aes128gcm16, aes192gcm16, aes256gcm16"
+	authentication_algorithm := "sha256, sha512, sha384, disabled"
+	encryption_algorithm := "aes128, aes256, aes128gcm16, aes192gcm16, aes256gcm16"
 	pfs := "disabled, group_2, group_5, group_14, group_19, group_15, group_16, group_17, group_18, group_20, group_21, group_22, group_23, group_24, group_31"
 	validateSchema = append(validateSchema,
 		validate.ValidateSchema{

--- a/ibm/service/vpc/resource_ibm_is_ipsec_policy_test.go
+++ b/ibm/service/vpc/resource_ibm_is_ipsec_policy_test.go
@@ -30,9 +30,9 @@ func TestAccIBMISIPSecPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_is_ipsec_policy.example", "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "authentication_algorithm", "md5"),
+						"ibm_is_ipsec_policy.example", "authentication_algorithm", "sha256"),
 					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "encryption_algorithm", "triple_des"),
+						"ibm_is_ipsec_policy.example", "encryption_algorithm", "aes128"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_ipsec_policy.example", "pfs", "disabled"),
 				),
@@ -43,9 +43,9 @@ func TestAccIBMISIPSecPolicy_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_is_ipsec_policy.example", "name", name),
 					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "authentication_algorithm", "sha1"),
+						"ibm_is_ipsec_policy.example", "authentication_algorithm", "sha512"),
 					resource.TestCheckResourceAttr(
-						"ibm_is_ipsec_policy.example", "encryption_algorithm", "aes128"),
+						"ibm_is_ipsec_policy.example", "encryption_algorithm", "aes256"),
 					resource.TestCheckResourceAttr(
 						"ibm_is_ipsec_policy.example", "pfs", "group_2"),
 				),
@@ -105,8 +105,8 @@ func testAccCheckIBMISIPSecPolicyConfig(name string) string {
 	return fmt.Sprintf(`
 		resource "ibm_is_ipsec_policy" "example" {
 			name = "%s"
-			authentication_algorithm = "md5"
-			encryption_algorithm = "triple_des"
+			authentication_algorithm = "sha256"
+			encryption_algorithm = "aes128"
 			pfs = "disabled"
 		}
 	`, name)
@@ -116,8 +116,8 @@ func testAccCheckIBMISIPSecPolicyConfigUpdate(name string) string {
 	return fmt.Sprintf(`
 		resource "ibm_is_ipsec_policy" "example" {
 			name = "%s"
-			authentication_algorithm = "sha1"
-			encryption_algorithm = "aes128"
+			authentication_algorithm = "sha512"
+			encryption_algorithm = "aes256"
 			pfs = "group_2"
 		}
 	`, name)

--- a/website/docs/r/is_ike_policy.html.markdown
+++ b/website/docs/r/is_ike_policy.html.markdown
@@ -40,21 +40,9 @@ resource "ibm_is_ike_policy" "example" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
-- `authentication_algorithm` - (Required, String) Enter the algorithm that you want to use to authenticate `IKE` peers. Available options are `md5`, `sha1`,  `sha256`, `sha512`, `sha384`.
-  
-  ~> **Note**
-  The `md5` and `sha1` algorithms have been deprecated and support will be removed from November 2022
-
-- `dh_group`  - (Required, Integer) Enter the Diffie-Hellman group that you want to use for the encryption key. Available enumeration type are `2`, `5`, `14`, `19`, `15`, `16` ,`17` ,`18` ,`20` ,`21` ,`22` ,`23` ,`24` ,`31`
-
-  ~> **Note**
-  The Diffie-Hellman Groups 2 and 5 have been deprecated and support will be removed from November 2022
-
-- `encryption_algorithm` - (Required, String) Enter the algorithm that you want to use to encrypt data. Available options are: `triple_des`, `aes128`, `aes192`, `aes256`.
-
-  ~> **Note**
-  The `triple_des` algorithm has been deprecated and support will be removed from November 2022
-
+- `authentication_algorithm` - (Required, String) Enter the algorithm that you want to use to authenticate `IKE` peers. Available options are `sha256`, `sha512`, `sha384`.
+- `dh_group`  - (Required, Integer) Enter the Diffie-Hellman group that you want to use for the encryption key. Available enumeration type are `14`, `19`, `15`, `16` ,`17` ,`18` ,`20` ,`21` ,`22` ,`23` ,`24` ,`31`
+- `encryption_algorithm` - (Required, String) Enter the algorithm that you want to use to encrypt data. Available options are: `aes128`, `aes192`, `aes256`.
 - `ike_version`  - (Optional, Integer) Enter the IKE protocol version that you want to use. Available options are `1`, or `2`.
 - `key_lifetime`  - (Optional, Integer)The key lifetime in seconds. `Maximum: 86400`, `Minimum: 1800`. Default is `28800`. 
 - `name` - (Required, String) Enter a name for your IKE policy.

--- a/website/docs/r/is_ipsec_policy.html.markdown
+++ b/website/docs/r/is_ipsec_policy.html.markdown
@@ -37,18 +37,12 @@ resource "ibm_is_ipsec_policy" "example" {
 ## Argument reference
 Review the argument references that you can specify for your resource. 
 
-- `authentication_algorithm` - (Required, String) Enter the algorithm that you want to use to authenticate `IPSec` peers. Available options are `md5`, `sha1`,  `sha256`, `sha512`, `sha384`, `disabled`.
-
-  ~> **Note**
-  The `md5` and `sha1` algorithms have been deprecated and support will be removed from November 2022
+- `authentication_algorithm` - (Required, String) Enter the algorithm that you want to use to authenticate `IPSec` peers. Available options are `sha256`, `sha512`, `sha384`, `disabled`.
 
   ~> **Note**
   `authentication_algorithm` must be set to `disabled` if and only if the `encryption_algorithm` is `aes128gcm16`, `aes192gcm16`, or `aes256gcm16`
 
-- `encryption_algorithm` - (Required, String) Enter the algorithm that you want to use to encrypt data. Available options are: `triple_des`, `aes128`, `aes192`, `aes256`, `aes128gcm16`, `aes192gcm16`, `aes256gcm16`
-
-  ~> **Note**
-  The `triple_des` algorithm has been deprecated and support will be removed from November 2022
+- `encryption_algorithm` - (Required, String) Enter the algorithm that you want to use to encrypt data. Available options are: `aes128`, `aes192`, `aes256`, `aes128gcm16`, `aes192gcm16`, `aes256gcm16`
 
 - `key_lifetime`  - (Optional, Integer) Enter the time in seconds that your encryption key can be used before it expires. You must enter a number between 300 and 86400. If you do not specify this option, 3600 seconds is used.
 - `name` - (Required, String) Enter the name for your IPSec policy.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIPSecPolicy_basic'
=== RUN   TestAccIBMISIPSecPolicy_basic
--- PASS: TestAccIBMISIPSecPolicy_basic (73.61s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     75.269s

$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISIKEPolicy_basic'
=== RUN   TestAccIBMISIKEPolicy_basic
--- PASS: TestAccIBMISIKEPolicy_basic (74.78s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     76.725s
...
```
