### PR TITLE
Security Group Rule ICMP Type, Code -> Any

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_security_group_rule.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_group_rule.go
@@ -202,13 +202,25 @@ func dataSourceIBMIsSecurityGroupRuleRead(context context.Context, d *schema.Res
 					return diag.FromErr(fmt.Errorf("Error setting remote %s", err))
 				}
 			}
+			if securityGroupRule.Code != nil {
+				if err = d.Set("code", flex.IntValue(securityGroupRule.Code)); err != nil {
+					return diag.FromErr(fmt.Errorf("Error setting code: %s", err))
+				}
+			} else {
+				if err = d.Set("code", int64(256)); err != nil {
+					return diag.FromErr(fmt.Errorf("Error setting code: %s", err))
+				}
+			}
+			if securityGroupRule.Type != nil {
+				if err = d.Set("type", flex.IntValue(securityGroupRule.Type)); err != nil {
+					return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
+				}
+			} else {
+				if err = d.Set("type", int64(255)); err != nil {
+					return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
+				}
+			}
 
-			if err = d.Set("code", flex.IntValue(securityGroupRule.Code)); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting code: %s", err))
-			}
-			if err = d.Set("type", flex.IntValue(securityGroupRule.Type)); err != nil {
-				return diag.FromErr(fmt.Errorf("Error setting type: %s", err))
-			}
 		}
 	case "*vpcv1.SecurityGroupRuleSecurityGroupRuleProtocolTcpudp":
 		{

--- a/ibm/service/vpc/data_source_ibm_is_security_group_rules.go
+++ b/ibm/service/vpc/data_source_ibm_is_security_group_rules.go
@@ -177,9 +177,17 @@ func dataSourceIBMIsSecurityGroupRulesRead(d *schema.ResourceData, meta interfac
 				l["href"] = *rulex.Href
 				l["id"] = *rulex.ID
 				l["ip_version"] = *rulex.IPVersion
-				l["code"] = *rulex.Code
+				if rulex.Code != nil {
+					l["code"] = *rulex.Code
+				} else {
+					l["code"] = 256
+				}
 				l["protocol"] = *rulex.Protocol
-				l["type"] = *rulex.Type
+				if rulex.Type != nil {
+					l["type"] = *rulex.Type
+				} else {
+					l["type"] = 255
+				}
 				// remote
 				if rulex.Remote != nil {
 					remoteList := []map[string]interface{}{}

--- a/ibm/service/vpc/resource_ibm_is_security_group_rule_test.go
+++ b/ibm/service/vpc/resource_ibm_is_security_group_rule_test.go
@@ -149,6 +149,16 @@ func testAccCheckIBMISsecurityGroupRuleConfig(vpcname, name string) string {
 		}
 	  }
 	  
+	  resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_code_any" {
+		depends_on = [ibm_is_security_group_rule.testacc_security_group_rule_icmp]
+		group      = ibm_is_security_group.testacc_security_group.id
+		direction  = "inbound"
+		remote     = "127.0.0.1"
+		icmp {
+		  type = 30
+		}
+	  }
+
 	  resource "ibm_is_security_group_rule" "testacc_security_group_rule_udp" {
 		depends_on = [ibm_is_security_group_rule.testacc_security_group_rule_icmp]
 		group      = ibm_is_security_group.testacc_security_group.id

--- a/website/docs/d/is_security_group_rule.html.markdown
+++ b/website/docs/d/is_security_group_rule.html.markdown
@@ -32,8 +32,9 @@ Review the argument reference that you can specify for your data source.
 
 In addition to all argument references listed, you can access the following attribute references after your data source is created.
 
-- `id` - The unique identifier of the is_security_group_rule.
-- `code` - (Integer) The ICMP traffic code to allow.
+- `id` - The unique identifier of the is_security_group_rule. 
+
+- `code` - (Integer) The ICMP traffic code to allow, value `256` indicates all codes are allowed.
 
 - `direction` - (String) The direction of traffic to enforce, either `inbound` or `outbound`.
 
@@ -59,5 +60,5 @@ Nested scheme for `remote`:
 	- `id` - (String) The unique identifier for this security group.
 	- `name` - (String) The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
 
-- `type` - (Integer) The ICMP traffic type to allow.
+- `type` - (Integer) The ICMP traffic type to allow, value `255` indicates all types are allowed.
 

--- a/website/docs/d/is_security_group_rules.html.markdown
+++ b/website/docs/d/is_security_group_rules.html.markdown
@@ -32,7 +32,7 @@ In addition to all argument references listed, you can access the following attr
 - `id` - The unique identifier of the SecurityGroupRuleCollection.
 - `rules` - (List) Array of rules.
 Nested scheme for `rules`:
-	- `code` - (Integer) The ICMP traffic code to allow.
+	- `code` - (Integer) The ICMP traffic code to allow, value `256` indicates all codes are allowed.
 	- `direction` - (String) The direction of traffic to enforce, either `inbound` or `outbound`.
 	- `href` - (String) The URL for this security group rule.
 	- `id` - (String) The unique identifier for this security group rule.
@@ -51,5 +51,5 @@ Nested scheme for `rules`:
 		- `href` - (String) The security group's canonical URL.
 		- `id` - (String) The unique identifier for this security group.
 		- `name` - (String) The user-defined name for this security group. Names must be unique within the VPC the security group resides in.
-	- `type` - (Integer) The ICMP traffic type to allow.
+	- `type` - (Integer) The ICMP traffic type to allow, value `255` indicates all types are allowed.
 

--- a/website/docs/r/is_security_group_rule.html.markdown
+++ b/website/docs/r/is_security_group_rule.html.markdown
@@ -105,8 +105,8 @@ Review the argument references that you can specify for your resource.
 - `icmp` - (Optional, List) A nested block describes the `icmp` protocol of this security group rule.
 
   Nested scheme for `icmp`:
-  - `type`- (Required, Integer) The ICMP traffic type to allow. Valid values from 0 to 254.
-  - `code` - (Optional, Integer) The ICMP traffic code to allow. Valid values from 0 to 255.
+  - `type`- (Required, Integer) The ICMP traffic type to allow. Valid values from 0 to 254. Please specify value `255` to allow `all` types.
+  - `code` - (Optional, Integer) The ICMP traffic code to allow. Valid values from 0 to 255. Please specify value `256` to allow `all` codes
 - `remote` - (Optional, String) Security group ID, an IP address, a CIDR block, or a single security group identifier.
 - `tcp` - (Optional, List) A nested block describes the `tcp` protocol of this security group rule.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISSecurityGroupRule_basic'

```
<img width="710" alt="Screenshot 2022-11-22 at 12 33 16 PM" src="https://user-images.githubusercontent.com/78336632/203265639-a37a8260-2b80-4854-baeb-2c8c6ffc0504.png">

```
resource "ibm_is_vpc" "testacc_vpc" {
  name = "sunitha"
}

resource "ibm_is_security_group" "testacc_security_group" {
  name = "sunitha-sg"
  vpc  = ibm_is_vpc.testacc_vpc.id
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_all" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  icmp {
    code = 256
    type = 30
  }
}
resource "ibm_is_security_group_rule" "testacc_security_group_rule_icmp_any" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  icmp {
    # code = 256
    # type = 30
  }
}

resource "ibm_is_security_group_rule" "testacc_security_group_rule_tcp" {
  group     = ibm_is_security_group.testacc_security_group.id
  direction = "inbound"
  remote    = "127.0.0.1"
  tcp {
    # code = 256
    # type = 30
  }
}

data "ibm_is_security_group_rules" "example" {
  security_group = ibm_is_security_group.testacc_security_group.id
}

data "ibm_is_security_group_rule" "example" {
  security_group_rule = ibm_is_security_group_rule.testacc_security_group_rule_icmp.rule_id
  security_group      = ibm_is_security_group.testacc_security_group.id
}
```
