### PR TITLE
vpc address prefix and subnet doc fix

### DIFF
--- a/website/docs/r/is_subnet.html.markdown
+++ b/website/docs/r/is_subnet.html.markdown
@@ -96,7 +96,7 @@ Review the argument references that you can specify for your resource.
 - `ipv4_cidr_block` - (Optional, Forces new resource, String) The IPv4 range of the subnet.
 
   ~> **NOTE:**
-    - if using a IPv4 range from a `ibm_is_vpc_address_prefix` resource, add a `depends_on` to handle hidden `ibm_is_vpc_address_prefix` dependency if not using interpolation.
+    If using a IPv4 range from a `ibm_is_vpc_address_prefix` resource, add a `depends_on` to handle hidden `ibm_is_vpc_address_prefix` dependency if not using interpolation.
 
 - `ip_version` - (Optional, Forces new resource, String) The IP Version. The default is `ipv4`.
 - `name` - (Required, String) The name of the subnet.
@@ -106,6 +106,10 @@ Review the argument references that you can specify for your resource.
 - `routing_table` - (Optional, String) The routing table ID associated with the subnet.
 - `tags`  - (Optional, List of Strings) The tags associated with the subnet.
 - `total_ipv4_address_count` - (Optional, Forces new resource, String) The total number of IPv4 addresses. Either `ipv4_cidr_block` or `total_pv4_address_count` input parameters must be provided in the resource.
+  
+  ~> **Note** 
+  The VPC must have a default address prefix in the specified zone, and that prefix must have a free CIDR range with at least this number of addresses.
+
 - `vpc` - (Required, Forces new resource, String) The VPC ID.
 - `zone` - (Required, Forces new resource, String) The subnet zone name.
 

--- a/website/docs/r/is_vpc_address_prefix.html.markdown
+++ b/website/docs/r/is_vpc_address_prefix.html.markdown
@@ -42,7 +42,7 @@ resource "ibm_is_vpc_address_prefix" "example" {
 Review the argument references that you can specify for your resource. 
 
 - `cidr` - (Required, Forces new resource, String) The CIDR block for the address prefix.
-- `is_default` - (Optional, String) Makes the prefix as default prefix for this zone in this VPC.
+- `is_default` - (Optional, Boolean) Makes the prefix as default prefix for this zone in this VPC. Default is `false`
 - `name` - (Required, String) The address prefix name.No.
 - `vpc` - (Required, Forces new resource, String) The VPC ID.
 - `zone` - (Required, Forces new resource, String) The name of the zone.
@@ -54,6 +54,7 @@ In addition to all argument reference list, you can access the following attribu
 - `id` - (String) The ID of the address prefix. The ID is composed of `<vpc_id>/<address_prefix_id>`.
 - `has_subnets`- (Bool) Indicates whether subnets exist with addresses from this prefix.
 - `address_prefix` - (String) the unique identifier of the address prefix.
+- `related_crn` - (String) CRN of the VPC this address prefix belongs to.
 
 ## Import
 The `ibm_is_vpc_address_prefix` resource can be imported by using the VPC ID and VPC address prefix ID.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
