### PR TITLE
Added the next_hop details in vpc routing table routes data source

### DIFF
--- a/website/docs/d/is_vpc_routing_table_routes.html.markdown
+++ b/website/docs/d/is_vpc_routing_table_routes.html.markdown
@@ -74,6 +74,16 @@ In addition to all argument reference list, you can access the following attribu
 	- `action` - (String) The action to perform with a packet matching the route.
 	- `destination` - (String) The destination of the route.
 	- `next_hop` - (String) The next hop address of the route.
+	- `next_hop_details` - (List) If `action` is `deliver`, the next hop that packets will be delivered to.  Forother `action` values, its `address` will be `0.0.0.0`. This is to list the details of the nexthop information.
+		Nested scheme for `next_hop`:
+		- `address` - (String) The IP address.This property may add support for IPv6 addresses in the future. When processing a value in this property, verify that the address is in an expected format. If it is not, log an error. Optionally halt processing and surface the error, or bypass the resource on which the unexpected IP address format was encountered.
+		- `deleted` - (List) If present, this property indicates the referenced resource has been deleted, and providessome supplementary information.
+			Nested scheme for `deleted`:
+			- `more_info` - (String) Link to documentation about deleted resources.
+		- `href` - (String) The VPN connection's canonical URL.
+		- `id` - (String) The unique identifier for this VPN gateway connection.
+		- `name` - (String) The name for this VPN gateway connection. The name is unique across all connections for the VPN gateway.
+		- `resource_type` - (String) The resource type.
 	- `origin` - (String) The origin of this route:- `service`: route was directly created by a service - `user`: route was directly created by a userThe enumerated values for this property are expected to expand in the future. When processing this property, check for and log unknown values. Optionally halt processing and surface the error, or bypass the route on which the unexpected property value was encountered.
   		- Constraints: Allowable values are: `learned`, `service`, `user`.
 	- `zone` - (String) The zone name of the route.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

Test results using TF:
```
Changes to Outputs:
  ~ routesds = {
      ~ id            = "2023-02-01 06:13:31.443141 +0000 UTC" -> "2023-02-01 04:37:30.300593 +0000 UTC"
      ~ routes        = null -> [
          + {
              + action           = ""
              + created_at       = "2023-02-01T06:12:03.000Z"
              + creator          = []
              + destination      = "192.168.4.0/24"
              + href             = "https://us-south.iaas.cloud.ibm.com/v1/vpcs/r006-590dfdcf-da62-4a2f-834e-b73c48830648/routing_tables/r006-8c6e0ed3-4c3d-4280-a333-fa2d1351e31e/routes/r006-38b166dd-8989-48d9-9021-e93ed7f45308"
              + lifecycle_state  = "stable"
              + name             = "custom-route-2"
              + next_hop_details = [
                  + {
                      + address       = ""
                      + deleted       = []
                      + href          = "https://us-south.iaas.cloud.ibm.com/v1/vpn_gateways/0717-414e6242-c8e2-48c7-82d7-7abd43a98249/connections/0717-8814f6b9-9b33-4097-bc7c-af5f5c02c2d6"
                      + id            = "0717-8814f6b9-9b33-4097-bc7c-af5f5c02c2d6"
                      + name          = "example-vpn-gateway-connection"
                      + resource_type = "vpn_gateway_connection"
                    },
                ]
              + nexthop          = "0717-8814f6b9-9b33-4097-bc7c-af5f5c02c2d6"
              + origin           = "user"
              + route_id         = "r006-38b166dd-8989-48d9-9021-e93ed7f45308"
              + zone             = "us-south-1"
            },
        ]
        # (2 unchanged elements hidden)
    }

...
```