### PR TITLE
fix(image) : added length check for volume attachments

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -80,7 +80,8 @@ var DedicatedHostGroupFamily string
 var DedicatedHostGroupClass string
 var ShareProfileName string
 var VolumeProfileName string
-var UnattachedBootVolumeID string
+var VSIUnattachedBootVolumeID string
+var VSIDataVolumeID string
 var ISRouteDestination string
 var ISRouteNextHop string
 var WorkspaceID string
@@ -652,10 +653,15 @@ func init() {
 		VolumeProfileName = "general-purpose"
 		fmt.Println("[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'")
 	}
-	UnattachedBootVolumeID = os.Getenv("IS_UNATTACHED_BOOT_VOLUME_ID")
-	if UnattachedBootVolumeID == "" {
-		UnattachedBootVolumeID = "r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e"
+	VSIUnattachedBootVolumeID = os.Getenv("IS_VSI_UNATTACHED_BOOT_VOLUME_ID")
+	if VSIUnattachedBootVolumeID == "" {
+		VSIUnattachedBootVolumeID = "r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e"
 		fmt.Println("[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'")
+	}
+	VSIDataVolumeID = os.Getenv("IS_VSI_DATA_VOLUME_ID")
+	if VSIDataVolumeID == "" {
+		VSIDataVolumeID = "r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e"
+		fmt.Println("[INFO] Set the environment variable IS_VSI_DATA_VOLUME_ID for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'")
 	}
 
 	ISRouteDestination = os.Getenv("SL_ROUTE_DESTINATION")

--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -80,6 +80,7 @@ var DedicatedHostGroupFamily string
 var DedicatedHostGroupClass string
 var ShareProfileName string
 var VolumeProfileName string
+var UnattachedBootVolumeID string
 var ISRouteDestination string
 var ISRouteNextHop string
 var WorkspaceID string
@@ -650,6 +651,11 @@ func init() {
 	if VolumeProfileName == "" {
 		VolumeProfileName = "general-purpose"
 		fmt.Println("[INFO] Set the environment variable IS_VOLUME_PROFILE for testing ibm_is_volume_profile else it is set to default value 'general-purpose'")
+	}
+	UnattachedBootVolumeID = os.Getenv("IS_UNATTACHED_BOOT_VOLUME_ID")
+	if UnattachedBootVolumeID == "" {
+		UnattachedBootVolumeID = "r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e"
+		fmt.Println("[INFO] Set the environment variable IS_UNATTACHED_BOOT_VOLUME_NAME for testing ibm_is_image else it is set to default value 'r006-1cbe9f0a-7101-4d25-ae72-2a2d725e530e'")
 	}
 
 	ISRouteDestination = os.Getenv("SL_ROUTE_DESTINATION")

--- a/ibm/service/vpc/resource_ibm_is_image.go
+++ b/ibm/service/vpc/resource_ibm_is_image.go
@@ -363,6 +363,9 @@ func imgCreateByVolume(d *schema.ResourceData, meta interface{}, name, volume st
 		return fmt.Errorf("[ERROR] Error creating Image because the specified source_volume %s is not attached to a virtual server instance ", volume)
 	}
 	volAtt := &vol.VolumeAttachments[0]
+	if *volAtt.Type != "boot" {
+		return fmt.Errorf("[ERROR] Error creating Image because the specified source_volume %s is not boot volume ", volume)
+	}
 	insId = *volAtt.Instance.ID
 	getinsOptions := &vpcv1.GetInstanceOptions{
 		ID: &insId,

--- a/ibm/service/vpc/resource_ibm_is_image.go
+++ b/ibm/service/vpc/resource_ibm_is_image.go
@@ -360,11 +360,11 @@ func imgCreateByVolume(d *schema.ResourceData, meta interface{}, name, volume st
 		return fmt.Errorf("[ERROR] Error retrieving Volume (%s) details: %s\n%s", volume, err, response)
 	}
 	if vol.VolumeAttachments == nil || len(vol.VolumeAttachments) == 0 {
-		return fmt.Errorf("[ERROR] Error creating Image because the specified source_volume %s is not attached to a virtual server instance ", volume)
+		return fmt.Errorf("[ERROR] Error creating Image because the specified source_volume %s is not attached to a virtual server instance", volume)
 	}
 	volAtt := &vol.VolumeAttachments[0]
 	if *volAtt.Type != "boot" {
-		return fmt.Errorf("[ERROR] Error creating Image because the specified source_volume %s is not boot volume ", volume)
+		return fmt.Errorf("[ERROR] Error creating Image because the specified source_volume %s is not boot volume", volume)
 	}
 	insId = *volAtt.Instance.ID
 	getinsOptions := &vpcv1.GetInstanceOptions{

--- a/ibm/service/vpc/resource_ibm_is_image.go
+++ b/ibm/service/vpc/resource_ibm_is_image.go
@@ -359,7 +359,7 @@ func imgCreateByVolume(d *schema.ResourceData, meta interface{}, name, volume st
 	if err != nil || vol == nil {
 		return fmt.Errorf("[ERROR] Error retrieving Volume (%s) details: %s\n%s", volume, err, response)
 	}
-	if vol.VolumeAttachments == nil {
+	if vol.VolumeAttachments == nil || len(vol.VolumeAttachments) == 0 {
 		return fmt.Errorf("[ERROR] Error creating Image because the specified source_volume %s is not attached to a virtual server instance ", volume)
 	}
 	volAtt := &vol.VolumeAttachments[0]

--- a/ibm/service/vpc/resource_ibm_is_image_test.go
+++ b/ibm/service/vpc/resource_ibm_is_image_test.go
@@ -51,6 +51,10 @@ func TestAccIBMISImage_error(t *testing.T) {
 				Config:      testAccCheckIBMISImageError(name),
 				ExpectError: regexp.MustCompile("is not attached to a virtual server instance"),
 			},
+			{
+				Config:      testAccCheckIBMISImageError2(name),
+				ExpectError: regexp.MustCompile("is not boot volume"),
+			},
 		},
 	})
 }
@@ -207,7 +211,17 @@ func testAccCheckIBMISImageError(name string) string {
 			timeouts {
 				create = "45m"
 			}
-		}`, name, acc.UnattachedBootVolumeID)
+		}`, name, acc.VSIUnattachedBootVolumeID)
+}
+func testAccCheckIBMISImageError2(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_image" "isExampleImageFromVolume" {
+			name = "%s"
+			source_volume = "%s"
+			timeouts {
+				create = "45m"
+			}
+		}`, name, acc.VSIDataVolumeID)
 }
 
 func testAccCheckIBMISImageEncryptedConfig(name string) string {

--- a/ibm/service/vpc/resource_ibm_is_image_test.go
+++ b/ibm/service/vpc/resource_ibm_is_image_test.go
@@ -6,6 +6,7 @@ package vpc_test
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -34,6 +35,21 @@ func TestAccIBMISImage_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"ibm_is_image.isExampleImage", "name", name),
 				),
+			},
+		},
+	})
+}
+func TestAccIBMISImage_error(t *testing.T) {
+	name := fmt.Sprintf("tfimg-name-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheckImage(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: checkImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckIBMISImageError(name),
+				ExpectError: regexp.MustCompile("is not attached to a virtual server instance"),
 			},
 		},
 	})
@@ -182,6 +198,16 @@ func testAccCheckIBMISImageConfig1(vpcname, subnetname, sshname, publicKey, inst
 				create = "45m"
 			}
 		  }`, vpcname, subnetname, acc.ISZoneName, sshname, publicKey, instanceName, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName, name)
+}
+func testAccCheckIBMISImageError(name string) string {
+	return fmt.Sprintf(`
+		resource "ibm_is_image" "isExampleImageFromVolume" {
+			name = "%s"
+			source_volume = "%s"
+			timeouts {
+				create = "45m"
+			}
+		}`, name, acc.UnattachedBootVolumeID)
 }
 
 func testAccCheckIBMISImageEncryptedConfig(name string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMISImage_error
--- PASS: TestAccIBMISImage_error (11.21s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     13.286s
```
