### PR TITLE
Idle Connection Timeout FIx

### DIFF
--- a/ibm/service/vpc/data_source_ibm_is_lb_listeners.go
+++ b/ibm/service/vpc/data_source_ibm_is_lb_listeners.go
@@ -286,6 +286,9 @@ func dataSourceLoadBalancerListenerCollectionListenersToMap(listenersItem vpcv1.
 	if listenersItem.ConnectionLimit != nil {
 		listenersMap["connection_limit"] = listenersItem.ConnectionLimit
 	}
+	if listenersItem.IdleConnectionTimeout != nil {
+		listenersMap[isLBListenerIdleConnectionTimeout] = listenersItem.IdleConnectionTimeout
+	}
 	if listenersItem.CreatedAt != nil {
 		listenersMap["created_at"] = listenersItem.CreatedAt.String()
 	}

--- a/ibm/service/vpc/resource_ibm_is_lb_listener.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_listener.go
@@ -318,7 +318,7 @@ func lbListenerCreate(d *schema.ResourceData, meta interface{}, lbID, protocol, 
 			}
 		}
 	}
-	if idleconnectiontimeout, ok := d.GetOk(isLBListenerIdleConnectionTimeout); ok && strings.EqualFold(*lb.Profile.Family, "application") {
+	if idleconnectiontimeout, ok := d.GetOk(isLBListenerIdleConnectionTimeout); ok {
 		idleConnectionTimeout := int64(idleconnectiontimeout.(int))
 		options.IdleConnectionTimeout = &idleConnectionTimeout
 	}

--- a/ibm/service/vpc/resource_ibm_is_lb_listener.go
+++ b/ibm/service/vpc/resource_ibm_is_lb_listener.go
@@ -226,10 +226,6 @@ func resourceIBMISLBListenerCreate(d *schema.ResourceData, meta interface{}) err
 		defPool = lbPool
 	}
 
-	var idleConnectionTimeout int64
-	if idleconnectiontimeout, ok := d.GetOk(isLBListenerIdleConnectionTimeout); ok {
-		idleConnectionTimeout = int64(idleconnectiontimeout.(int))
-	}
 	if crn, ok := d.GetOk(isLBListenerCertificateInstance); ok {
 		certificateCRN = crn.(string)
 	}
@@ -262,7 +258,7 @@ func resourceIBMISLBListenerCreate(d *schema.ResourceData, meta interface{}) err
 	conns.IbmMutexKV.Lock(isLBKey)
 	defer conns.IbmMutexKV.Unlock(isLBKey)
 
-	err := lbListenerCreate(d, meta, lbID, protocol, defPool, certificateCRN, listener, uri, port, portMin, portMax, connLimit, httpStatusCode, idleConnectionTimeout)
+	err := lbListenerCreate(d, meta, lbID, protocol, defPool, certificateCRN, listener, uri, port, portMin, portMax, connLimit, httpStatusCode)
 	if err != nil {
 		return err
 	}
@@ -270,7 +266,7 @@ func resourceIBMISLBListenerCreate(d *schema.ResourceData, meta interface{}) err
 	return resourceIBMISLBListenerRead(d, meta)
 }
 
-func lbListenerCreate(d *schema.ResourceData, meta interface{}, lbID, protocol, defPool, certificateCRN, listener, uri string, port, portMin, portMax, connLimit, httpStatusCode, idleConnectionTimeout int64) error {
+func lbListenerCreate(d *schema.ResourceData, meta interface{}, lbID, protocol, defPool, certificateCRN, listener, uri string, port, portMin, portMax, connLimit, httpStatusCode int64) error {
 	sess, err := vpcClient(meta)
 	if err != nil {
 		return err
@@ -322,10 +318,10 @@ func lbListenerCreate(d *schema.ResourceData, meta interface{}, lbID, protocol, 
 			}
 		}
 	}
-	if strings.EqualFold(*lb.Profile.Family, "application") {
+	if idleconnectiontimeout, ok := d.GetOk(isLBListenerIdleConnectionTimeout); ok && strings.EqualFold(*lb.Profile.Family, "application") {
+		idleConnectionTimeout := int64(idleconnectiontimeout.(int))
 		options.IdleConnectionTimeout = &idleConnectionTimeout
 	}
-
 	if app, ok := d.GetOk(isLBListenerAcceptProxyProtocol); ok {
 		acceptProxyProtocol := app.(bool)
 		options.AcceptProxyProtocol = &acceptProxyProtocol
@@ -480,11 +476,12 @@ func lbListenerGet(d *schema.ResourceData, meta interface{}, lbID, lbListenerID 
 		d.Set(isLBListenerConnectionLimit, *lbListener.ConnectionLimit)
 	}
 	d.Set(isLBListenerStatus, *lbListener.ProvisioningStatus)
-	getLoadBalancerOptions := &vpcv1.GetLoadBalancerOptions{
-		ID: &lbID,
-	}
+
 	if lbListener.IdleConnectionTimeout != nil {
 		d.Set(isLBListenerIdleConnectionTimeout, *lbListener.IdleConnectionTimeout)
+	}
+	getLoadBalancerOptions := &vpcv1.GetLoadBalancerOptions{
+		ID: &lbID,
 	}
 	lb, response, err := sess.GetLoadBalancer(getLoadBalancerOptions)
 	if err != nil {

--- a/website/docs/d/is_lb_listener.html.markdown
+++ b/website/docs/d/is_lb_listener.html.markdown
@@ -68,7 +68,7 @@ In addition to all argument references listed, you can access the following attr
 		- `id` - (String) The unique identifier for this load balancer listener.
 	- `uri` - (String) The redirect relative target URI.
 
-- `idle_connection_timeout` - The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family. Default value is `50`.
+- `idle_connection_timeout` - (Integer) The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family.
 
 - `policies` - (List) The policies for this listener.
 Nested scheme for `policies`:

--- a/website/docs/d/is_lb_listener.html.markdown
+++ b/website/docs/d/is_lb_listener.html.markdown
@@ -68,7 +68,7 @@ In addition to all argument references listed, you can access the following attr
 		- `id` - (String) The unique identifier for this load balancer listener.
 	- `uri` - (String) The redirect relative target URI.
 
-- `idle_connection_timeout` - (Integer) The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family.
+- `idle_connection_timeout` - (Integer) The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family. Default value is `50`.
 
 - `policies` - (List) The policies for this listener.
 Nested scheme for `policies`:

--- a/website/docs/d/is_lb_listeners.html.markdown
+++ b/website/docs/d/is_lb_listeners.html.markdown
@@ -59,7 +59,7 @@ In addition to all argument references listed, you can access the following attr
         	- `id` - (String) The unique identifier for this load balancer listener.
     		- `uri` - (String) The redirect relative target URI.
 	- `id` - (String) The unique identifier for this load balancer listener.
-	- `idle_connection_timeout` - The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family. Default value is `50`.
+	- `idle_connection_timeout` - (Integer) The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family. Default value is `50`.
 	- `policies` - (List) The policies for this listener.
 		Nested scheme for `policies`:
 		- `deleted` - (List) If present, this property indicates the referenced resource has been deleted and providessome supplementary information.

--- a/website/docs/r/is_lb_listener.html.markdown
+++ b/website/docs/r/is_lb_listener.html.markdown
@@ -194,7 +194,7 @@ Review the argument references that you can specify for your resource.
 - `https_redirect_listener` - (Optional, String) ID of the listener that will be set as http redirect target.
 - `https_redirect_status_code` - (Optional, Integer) The HTTP status code to be returned in the redirect response, one of [301, 302, 303, 307, 308].
 - `https_redirect_uri` - (Optional, String) Target URI where traffic will be redirected.
-- `idle_connection_timeout` - (Optional, Integer) The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family. Default value is `50`.
+- `idle_connection_timeout` - (Optional, Integer) The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family. Default value is `50`, allowed value is between `50` - `7200`.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.

--- a/website/docs/r/is_lb_listener.html.markdown
+++ b/website/docs/r/is_lb_listener.html.markdown
@@ -194,7 +194,7 @@ Review the argument references that you can specify for your resource.
 - `https_redirect_listener` - (Optional, String) ID of the listener that will be set as http redirect target.
 - `https_redirect_status_code` - (Optional, Integer) The HTTP status code to be returned in the redirect response, one of [301, 302, 303, 307, 308].
 - `https_redirect_uri` - (Optional, String) Target URI where traffic will be redirected.
-- `idle_connection_timeout` - (Optional, Integer) The idle connection timeout of the listener in seconds. This property will be present for load balancers in the `application` family. Default value is `50`, allowed value is between `50` - `7200`.
+- `idle_connection_timeout` - (Optional, Integer) The idle connection timeout of the listener in seconds. Supported for load balancers in the `application` family. Default value is `50`, allowed value is between `50` - `7200`.
 
 ## Attribute reference
 In addition to all argument reference list, you can access the following attribute reference after your resource is created.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISLBListener_connTimeout'

```
<img width="692" alt="Screenshot 2023-04-04 at 11 09 23 PM" src="https://user-images.githubusercontent.com/127872893/229873389-171983fe-398c-47de-8d99-a87ca26f2adb.png">



Scenarios 1:
```
resource "ibm_is_lb_listener" "listener1" {
  lb                    = ibm_is_lb.application_01.id
  port                  = 9087
  protocol              = "http"
  accept_proxy_protocol = true
  /* idle_connection_timeout = 60  */
}

resource "ibm_is_lb_listener" "listener_network" {
  lb                    = ibm_is_lb.testacc_LB.id
  port                  = 8080
  protocol              = "udp"
  // accept_proxy_protocol = true
  //idle_connection_timeout = 60 
} 
```
<img width="1231" alt="Screenshot 2023-04-04 at 9 22 12 PM" src="https://user-images.githubusercontent.com/127872893/229848131-0f58b234-5c3c-4f43-b0ae-be4e63ebf067.png">

```
resource "ibm_is_lb_listener" "listener1" {
  lb                    = ibm_is_lb.application_01.id
  port                  = 9087
  protocol              = "http"
  accept_proxy_protocol = true
  idle_connection_timeout = 60 
}
```

<img width="652" alt="Screenshot 2023-04-04 at 9 23 01 PM" src="https://user-images.githubusercontent.com/127872893/229848317-48596928-a4de-4382-ae63-6cad2e1d9e8e.png">
<img width="595" alt="Screenshot 2023-04-04 at 9 24 33 PM" src="https://user-images.githubusercontent.com/127872893/229848710-fd49fe22-f05e-429a-999f-ad46e04831dd.png">

```
resource "ibm_is_lb_listener" "listener_network" {
  lb                    = ibm_is_lb.testacc_LB.id
  port                  = 8080
  protocol              = "udp"
  // accept_proxy_protocol = true
  idle_connection_timeout = 60 
} 
```
<img width="879" alt="Screenshot 2023-04-04 at 9 27 54 PM" src="https://user-images.githubusercontent.com/127872893/229849577-79a6d3fe-2007-4d57-8f6d-09863c39d358.png">

```
resource "ibm_is_lb_listener" "listener1" {
  lb                    = ibm_is_lb.application_01.id
  port                  = 9087
  protocol              = "http"
  accept_proxy_protocol = true
  idle_connection_timeout = 60 
}
```
<img width="656" alt="Screenshot 2023-04-04 at 9 55 40 PM" src="https://user-images.githubusercontent.com/127872893/229856358-d2712d58-4e94-42b2-9882-2237206e7b18.png">


