### PR TITLE
[Bugfix] Failed to update resource ibm_is_instance_group_manager_policy

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -595,7 +595,7 @@ func init() {
 	IsWinImage = os.Getenv("IS_WIN_IMAGE")
 	if IsWinImage == "" {
 		//IsWinImage = "a7a0626c-f97e-4180-afbe-0331ec62f32a" // classic windows machine: ibm-windows-server-2012-full-standard-amd64-1
-		IsWinImage = "r006-5f9568ae-792e-47e1-a710-5538b2bdfca7" // next gen windows machine: ibm-windows-server-2012-full-standard-amd64-3
+		IsWinImage = "r006-d2e0d0e9-0a4f-4c45-afd7-cab787030776" // next gen windows machine: ibm-windows-server-2012-full-standard-amd64-3
 		fmt.Println("[INFO] Set the environment variable IS_WIN_IMAGE for testing ibm_is_instance data source else it is set to default value 'r006-5f9568ae-792e-47e1-a710-5538b2bdfca7'")
 	}
 

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host.go
@@ -54,7 +54,12 @@ func DataSourceIbmIsDedicatedHost() *schema.Resource {
 							Computed:    true,
 							Description: "The VCPU architecture.",
 						},
-						"count": {
+						"manufacturer": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The VCPU manufacturer.",
+						},
+						"count": &schema.Schema{
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "The number of VCPUs assigned.",
@@ -314,7 +319,12 @@ func DataSourceIbmIsDedicatedHost() *schema.Resource {
 							Computed:    true,
 							Description: "The VCPU architecture.",
 						},
-						"count": {
+						"manufacturer": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The VCPU manufacturer.",
+						},
+						"count": &schema.Schema{
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "The number of VCPUs assigned.",
@@ -493,6 +503,10 @@ func dataSourceDedicatedHostAvailableVcpuToMap(availableVcpuItem vpcv1.Vcpu) (av
 	if availableVcpuItem.Architecture != nil {
 		availableVcpuMap["architecture"] = availableVcpuItem.Architecture
 	}
+	// Added AMD Support for the manufacturer.
+	if availableVcpuItem.Manufacturer != nil {
+		availableVcpuMap["manufacturer"] = availableVcpuItem.Manufacturer
+	}
 	if availableVcpuItem.Count != nil {
 		availableVcpuMap["count"] = availableVcpuItem.Count
 	}
@@ -644,6 +658,10 @@ func dataSourceDedicatedHostVcpuToMap(vcpuItem vpcv1.Vcpu) (vcpuMap map[string]i
 
 	if vcpuItem.Architecture != nil {
 		vcpuMap["architecture"] = vcpuItem.Architecture
+	}
+	// Added AMD Support for the manufacturer.
+	if vcpuItem.Manufacturer != nil {
+		vcpuMap["manufacturer"] = vcpuItem.Manufacturer
 	}
 	if vcpuItem.Count != nil {
 		vcpuMap["count"] = vcpuItem.Count

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_profile.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_profile.go
@@ -302,6 +302,24 @@ func DataSourceIbmIsDedicatedHostProfile() *schema.Resource {
 					},
 				},
 			},
+			"vcpu_manufacturer": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The type for this profile field.",
+						},
+						"value": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The VCPU manufacturer for a dedicated host with this profile.",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -376,6 +394,14 @@ func dataSourceIbmIsDedicatedHostProfileRead(context context.Context, d *schema.
 		err = d.Set("vcpu_count", dataSourceDedicatedHostProfileFlattenVcpuCount(*dedicatedHostProfile.VcpuCount.(*vpcv1.DedicatedHostProfileVcpu)))
 		if err != nil {
 			return diag.FromErr(fmt.Errorf("[ERROR] Error setting vcpu_count %s", err))
+		}
+	}
+
+	// Changes for the AMD Support, manufacturer information.
+	if dedicatedHostProfile.VcpuManufacturer != nil {
+		err = d.Set("vcpu_manufacturer", dataSourceDedicatedHostProfileFlattenVcpuManufacturer(*dedicatedHostProfile.VcpuManufacturer))
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("Error setting vcpu_architecture %s", err))
 		}
 	}
 
@@ -500,6 +526,29 @@ func dataSourceDedicatedHostProfileVcpuArchitectureToMap(vcpuArchitectureItem vp
 	}
 
 	return vcpuArchitectureMap
+}
+
+// Changes for AMD Support, manufacturer details.
+func dataSourceDedicatedHostProfileFlattenVcpuManufacturer(result vpcv1.DedicatedHostProfileVcpuManufacturer) (finalList []map[string]interface{}) {
+	finalList = []map[string]interface{}{}
+	finalMap := dataSourceDedicatedHostProfileVcpuManufacturerToMap(result)
+	finalList = append(finalList, finalMap)
+
+	return finalList
+}
+
+// AMD Support for manufacturer
+func dataSourceDedicatedHostProfileVcpuManufacturerToMap(vcpuManufacturerItem vpcv1.DedicatedHostProfileVcpuManufacturer) (vcpuManufacturerMap map[string]interface{}) {
+	vcpuManufacturerMap = map[string]interface{}{}
+
+	if vcpuManufacturerItem.Type != nil {
+		vcpuManufacturerMap["type"] = vcpuManufacturerItem.Type
+	}
+	if vcpuManufacturerItem.Value != nil {
+		vcpuManufacturerMap["value"] = vcpuManufacturerItem.Value
+	}
+
+	return vcpuManufacturerMap
 }
 
 func dataSourceDedicatedHostProfileFlattenVcpuCount(result vpcv1.DedicatedHostProfileVcpu) (finalList []map[string]interface{}) {

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_profile_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_profile_test.go
@@ -25,6 +25,7 @@ func TestAccIbmIsDedicatedHostProfileDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "name", acc.DedicatedHostProfileName),
 					resource.TestCheckResourceAttrSet(resName, "class"),
 					resource.TestCheckResourceAttrSet(resName, "family"),
+					resource.TestCheckResourceAttrSet(resName, "vcpu_manufacturer.#"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_profiles.go
@@ -311,6 +311,25 @@ func DataSourceIbmIsDedicatedHostProfiles() *schema.Resource {
 								},
 							},
 						},
+						"vcpu_manufacturer": &schema.Schema{
+							Type: schema.TypeList,
+
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The type for this profile field.",
+									},
+									"value": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "TThe VCPU manufacturer for a dedicated host with this profile.",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -467,6 +486,13 @@ func dataSourceDedicatedHostProfileCollectionProfilesToMap(profilesItem vpcv1.De
 		vcpuCountList = append(vcpuCountList, vcpuCountMap)
 		profilesMap["vcpu_count"] = vcpuCountList
 	}
+	// AMD Support, changes for manufacturer details.
+	if profilesItem.VcpuManufacturer != nil {
+		vcpuManufacturerList := []map[string]interface{}{}
+		vcpuManufacturerMap := dataSourceDedicatedHostProfileCollectionProfilesVcpuManufacturerToMap(*profilesItem.VcpuManufacturer)
+		vcpuManufacturerList = append(vcpuManufacturerList, vcpuManufacturerMap)
+		profilesMap["vcpu_manufacturer"] = vcpuManufacturerList
+	}
 
 	return profilesMap
 }
@@ -551,6 +577,20 @@ func dataSourceDedicatedHostProfileCollectionProfilesVcpuArchitectureToMap(vcpuA
 	}
 
 	return vcpuArchitectureMap
+}
+
+// AMD Changes, manufacturer details added.
+func dataSourceDedicatedHostProfileCollectionProfilesVcpuManufacturerToMap(vcpuManufacturerItem vpcv1.DedicatedHostProfileVcpuManufacturer) (vcpuManufacturerMap map[string]interface{}) {
+	vcpuManufacturerMap = map[string]interface{}{}
+
+	if vcpuManufacturerItem.Type != nil {
+		vcpuManufacturerMap["type"] = vcpuManufacturerItem.Type
+	}
+	if vcpuManufacturerItem.Value != nil {
+		vcpuManufacturerMap["value"] = vcpuManufacturerItem.Value
+	}
+
+	return vcpuManufacturerMap
 }
 
 func dataSourceDedicatedHostProfileCollectionProfilesVcpuCountToMap(vcpuCountItem vpcv1.DedicatedHostProfileVcpu) (vcpuCountMap map[string]interface{}) {

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_profiles_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_profiles_test.go
@@ -25,6 +25,7 @@ func TestAccIbmIsDedicatedHostProfilesDataSourceBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "profiles.0.name"),
 					resource.TestCheckResourceAttrSet(resName, "profiles.0.class"),
 					resource.TestCheckResourceAttrSet(resName, "profiles.0.family"),
+					resource.TestCheckResourceAttrSet(resName, "profiles.0.vcpu_manufacturer.#"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_host_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_host_test.go
@@ -32,6 +32,7 @@ func TestAccIbmIsDedicatedHostDSBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resName, "disks.#", "2"),
 					resource.TestCheckResourceAttrSet(resName, "disks.0.name"),
 					resource.TestCheckResourceAttrSet(resName, "disks.0.size"),
+					resource.TestCheckResourceAttrSet(resName, "vcpu.0.manufacturer"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_hosts.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_hosts.go
@@ -64,7 +64,12 @@ func DataSourceIbmIsDedicatedHosts() *schema.Resource {
 										Computed:    true,
 										Description: "The VCPU architecture.",
 									},
-									"count": {
+									"manufacturer": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The VCPU manufacturer.",
+									},
+									"count": &schema.Schema{
 										Type:        schema.TypeInt,
 										Computed:    true,
 										Description: "The number of VCPUs assigned.",
@@ -344,7 +349,12 @@ func DataSourceIbmIsDedicatedHosts() *schema.Resource {
 										Computed:    true,
 										Description: "The VCPU architecture.",
 									},
-									"count": {
+									"manufacturer": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The VCPU manufacturer.",
+									},
+									"count": &schema.Schema{
 										Type:        schema.TypeInt,
 										Computed:    true,
 										Description: "The number of VCPUs assigned.",
@@ -552,6 +562,10 @@ func dataSourceDedicatedHostCollectionDedicatedHostsAvailableVcpuToMap(available
 	if availableVcpuItem.Architecture != nil {
 		availableVcpuMap["architecture"] = availableVcpuItem.Architecture
 	}
+	// Added AMD Support for the manufacturer.
+	if availableVcpuItem.Manufacturer != nil {
+		availableVcpuMap["manufacturer"] = availableVcpuItem.Manufacturer
+	}
 	if availableVcpuItem.Count != nil {
 		availableVcpuMap["count"] = availableVcpuItem.Count
 	}
@@ -663,6 +677,10 @@ func dataSourceDedicatedHostCollectionDedicatedHostsVcpuToMap(vcpuItem vpcv1.Vcp
 
 	if vcpuItem.Architecture != nil {
 		vcpuMap["architecture"] = vcpuItem.Architecture
+	}
+	// Added AMD Support for the manufacturer.
+	if vcpuItem.Manufacturer != nil {
+		vcpuMap["manufacturer"] = vcpuItem.Manufacturer
 	}
 	if vcpuItem.Count != nil {
 		vcpuMap["count"] = vcpuItem.Count

--- a/ibm/service/vpc/data_source_ibm_is_dedicated_hosts_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_dedicated_hosts_test.go
@@ -42,6 +42,7 @@ func TestAccIbmIsDedicatedHostsDSBasic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resName, "dedicated_hosts.0.memory"),
 					resource.TestCheckResourceAttrSet(resName, "dedicated_hosts.0.host_group"),
 					resource.TestCheckResourceAttrSet(resName, "dedicated_hosts.0.zone"),
+					resource.TestCheckResourceAttrSet(resName, "dedicated_hosts.0.vcpu.0.manufacturer"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_instance.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance.go
@@ -485,6 +485,12 @@ func DataSourceIBMISInstance() *schema.Resource {
 							Computed:    true,
 							Description: "Instance vCPU count",
 						},
+						// Added for AMD support, manufacturer details.
+						isInstanceCPUManufacturer: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Instance vCPU Manufacturer",
+						},
 					},
 				},
 			},
@@ -762,6 +768,7 @@ func instanceGetByName(d *schema.ResourceData, meta interface{}, name string) er
 		currentCPU := map[string]interface{}{}
 		currentCPU[isInstanceCPUArch] = *instance.Vcpu.Architecture
 		currentCPU[isInstanceCPUCount] = *instance.Vcpu.Count
+		currentCPU[isInstanceCPUManufacturer] = *instance.Vcpu.Manufacturer // Added for AMD support, manufacturer details.
 		cpuList = append(cpuList, currentCPU)
 	}
 	d.Set(isInstanceCPU, cpuList)

--- a/ibm/service/vpc/data_source_ibm_is_instance_profile_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_profile_test.go
@@ -33,6 +33,8 @@ func TestAccIBMISInstanceProfileDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_architecture.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_count.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_manufacturer.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_manufacturer.0.type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_manufacturer.0.value"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "network_interface_count.0.type"),
 				),
 			},

--- a/ibm/service/vpc/data_source_ibm_is_instance_profile_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_profile_test.go
@@ -32,6 +32,7 @@ func TestAccIBMISInstanceProfileDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "port_speed.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_architecture.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_count.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "vcpu_manufacturer.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profile.test1", "network_interface_count.0.type"),
 				),
 			},

--- a/ibm/service/vpc/data_source_ibm_is_instance_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_profiles.go
@@ -714,7 +714,6 @@ func instanceProfilesList(d *schema.ResourceData, meta interface{}) error {
 			vcpuManufacturerMap := dataSourceInstanceProfileVcpuManufacturerToMap(*profile.VcpuManufacturer)
 			vcpuManufacturerList = append(vcpuManufacturerList, vcpuManufacturerMap)
 			l["vcpu_manufacturer"] = vcpuManufacturerList
-			// l["vcpu_manufacturer"] = dataSourceInstanceProfileFlattenVcpuManufacture(*profile.VcpuManufacturer)
 		}
 
 		if profile.Disks != nil {

--- a/ibm/service/vpc/data_source_ibm_is_instance_profiles.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_profiles.go
@@ -574,6 +574,29 @@ func DataSourceIBMISInstanceProfiles() *schema.Resource {
 								},
 							},
 						},
+						"vcpu_manufacturer": &schema.Schema{
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"default": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The default VCPU manufacturer for an instance with this profile.",
+									},
+									"type": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The type for this profile field.",
+									},
+									"value": &schema.Schema{
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "The VCPU manufacturer for an instance with this profile.",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -684,6 +707,16 @@ func instanceProfilesList(d *schema.ResourceData, meta interface{}) error {
 			vcpuCountList = append(vcpuCountList, vcpuCountMap)
 			l["vcpu_count"] = vcpuCountList
 		}
+		// Changes for manufacturer for AMD Support.
+		// reduce the line of code here. - sumit's suggestions
+		if profile.VcpuManufacturer != nil {
+			vcpuManufacturerList := []map[string]interface{}{}
+			vcpuManufacturerMap := dataSourceInstanceProfileVcpuManufacturerToMap(*profile.VcpuManufacturer)
+			vcpuManufacturerList = append(vcpuManufacturerList, vcpuManufacturerMap)
+			l["vcpu_manufacturer"] = vcpuManufacturerList
+			// l["vcpu_manufacturer"] = dataSourceInstanceProfileFlattenVcpuManufacture(*profile.VcpuManufacturer)
+		}
+
 		if profile.Disks != nil {
 			l[isInstanceDisks] = dataSourceInstanceProfileFlattenDisks(profile.Disks)
 			if err != nil {

--- a/ibm/service/vpc/data_source_ibm_is_instance_profiles_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_profiles_test.go
@@ -35,6 +35,8 @@ func TestAccIBMISInstanceProfilesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.network_interface_count.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.network_interface_count.0.type"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.vcpu_manufacturer.#"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.vcpu_manufacturer.0.type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.vcpu_manufacturer.0.value"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_instance_profiles_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_profiles_test.go
@@ -34,6 +34,7 @@ func TestAccIBMISInstanceProfilesDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.vcpu_count.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.network_interface_count.#"),
 					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.network_interface_count.0.type"),
+					resource.TestCheckResourceAttrSet("data.ibm_is_instance_profiles.test1", "profiles.0.vcpu_manufacturer.#"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_instance_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_test.go
@@ -41,6 +41,8 @@ func TestAccIBMISInstanceDataSource_basic(t *testing.T) {
 						resName, "lifecycle_state"),
 					resource.TestCheckResourceAttr(
 						resName, "lifecycle_reasons.#", "0"),
+					resource.TestCheckResourceAttrSet(
+						resName, "vcpu.0.manufacturer"),
 				),
 			},
 		},

--- a/ibm/service/vpc/data_source_ibm_is_instance_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instance_test.go
@@ -42,6 +42,8 @@ func TestAccIBMISInstanceDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resName, "lifecycle_reasons.#", "0"),
 					resource.TestCheckResourceAttrSet(
+						resName, "vcpu.#"),
+					resource.TestCheckResourceAttrSet(
 						resName, "vcpu.0.manufacturer"),
 				),
 			},

--- a/ibm/service/vpc/data_source_ibm_is_instances.go
+++ b/ibm/service/vpc/data_source_ibm_is_instances.go
@@ -558,6 +558,11 @@ func DataSourceIBMISInstances() *schema.Resource {
 										Computed:    true,
 										Description: "Instance vcpu count",
 									},
+									"manufacturer": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: "Instance vcpu manufacturer",
+									},
 								},
 							},
 						},
@@ -1049,6 +1054,7 @@ func instancesList(d *schema.ResourceData, meta interface{}) error {
 			currentCPU := map[string]interface{}{}
 			currentCPU["architecture"] = *instance.Vcpu.Architecture
 			currentCPU["count"] = *instance.Vcpu.Count
+			currentCPU["manufacturer"] = *instance.Vcpu.Manufacturer
 			cpuList = append(cpuList, currentCPU)
 		}
 		l["vcpu"] = cpuList

--- a/ibm/service/vpc/data_source_ibm_is_instances_test.go
+++ b/ibm/service/vpc/data_source_ibm_is_instances_test.go
@@ -57,6 +57,7 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 					resource.TestCheckResourceAttrSet(resName, "instances.0.availability_policy_host_failure"),
 					resource.TestCheckResourceAttrSet(resName, "instances.0.lifecycle_state"),
 					resource.TestCheckResourceAttr(resName, "instances.0.lifecycle_reasons.#", "0"),
+					resource.TestCheckResourceAttrSet(resName, "instances.0.vcpu.0.manufacturer"),
 				),
 			},
 		},

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -720,6 +720,11 @@ func ResourceIBMISInstance() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						isInstanceCPUManufacturer: {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The VCPU manufacturer",
+						},
 					},
 				},
 			},
@@ -3138,6 +3143,7 @@ func instanceGet(d *schema.ResourceData, meta interface{}, id string) error {
 		currentCPU := map[string]interface{}{}
 		currentCPU[isInstanceCPUArch] = *instance.Vcpu.Architecture
 		currentCPU[isInstanceCPUCount] = *instance.Vcpu.Count
+		currentCPU[isInstanceCPUManufacturer] = instance.Vcpu.Manufacturer
 		cpuList = append(cpuList, currentCPU)
 	}
 	d.Set(isInstanceCPU, cpuList)

--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -55,6 +55,7 @@ const (
 	isInstanceCPUArch                 = "architecture"
 	isInstanceCPUCores                = "cores"
 	isInstanceCPUCount                = "count"
+	isInstanceCPUManufacturer         = "manufacturer"
 	isInstanceGpu                     = "gpu"
 	isInstanceGpuCores                = "cores"
 	isInstanceGpuCount                = "count"

--- a/ibm/service/vpc/resource_ibm_is_instance_group_manager_policy.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_group_manager_policy.go
@@ -193,6 +193,12 @@ func resourceIBMISInstanceGroupManagerPolicyUpdate(d *schema.ResourceData, meta 
 		updateInstanceGroupManagerPolicyOptions.InstanceGroupID = &instanceGroupID
 		updateInstanceGroupManagerPolicyOptions.InstanceGroupManagerID = &instanceGroupManagerID
 
+		instanceGroupManagerPolicyAsPatch, asPatchErr := instanceGroupManagerPolicyPatchModel.AsPatch()
+		if asPatchErr != nil {
+			return fmt.Errorf("[ERROR] Error calling asPatch for RoutingTablePatchModel: %s", asPatchErr)
+		}
+		updateInstanceGroupManagerPolicyOptions.InstanceGroupManagerPolicyPatch = instanceGroupManagerPolicyAsPatch
+
 		isInsGrpKey := "Instance_Group_Key_" + instanceGroupID
 		conns.IbmMutexKV.Lock(isInsGrpKey)
 		defer conns.IbmMutexKV.Unlock(isInsGrpKey)
@@ -245,7 +251,6 @@ func resourceIBMISInstanceGroupManagerPolicyRead(d *schema.ResourceData, meta in
 	d.Set("policy_id", instanceGroupManagerPolicyID)
 	d.Set("instance_group", instanceGroupID)
 	d.Set("instance_group_manager", instanceGroupManagerID)
-
 	return nil
 }
 
@@ -261,6 +266,21 @@ func resourceIBMISInstanceGroupManagerPolicyDelete(d *schema.ResourceData, meta 
 	instanceGroupID := parts[0]
 	instanceGroupManagerID := parts[1]
 	instanceGroupManagerPolicyID := parts[2]
+
+	// getInstanceGroupManagerPolicyOptions := vpcv1.GetInstanceGroupManagerPolicyOptions{
+	// 	ID:                     &instanceGroupManagerPolicyID,
+	// 	InstanceGroupID:        &instanceGroupID,
+	// 	InstanceGroupManagerID: &instanceGroupManagerID,
+	// }
+	// _, response, err := sess.GetInstanceGroupManagerPolicy(&getInstanceGroupManagerPolicyOptions)
+	// if err != nil {
+	// 	if response != nil && response.StatusCode == 404 {
+	// 		d.SetId("")
+	// 		return nil
+	// 	}
+	// 	return fmt.Errorf("[ERROR] Error Getting InstanceGroup Manager Policy: %s\n%s", err, response)
+	// }
+	// eTag := response.Headers.Get("ETag")
 
 	deleteInstanceGroupManagerPolicyOptions := vpcv1.DeleteInstanceGroupManagerPolicyOptions{
 		ID:                     &instanceGroupManagerPolicyID,

--- a/ibm/service/vpc/resource_ibm_is_instance_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_test.go
@@ -46,6 +46,10 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_instance.testacc_instance", "user_data", userData1),
 					resource.TestCheckResourceAttr(
 						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "vcpu.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "vcpu.0.manufacturer"),
 				),
 			},
 			{
@@ -60,6 +64,10 @@ ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVE
 						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
 					resource.TestCheckResourceAttrSet(
 						"ibm_is_instance.testacc_instance", "primary_network_interface.0.port_speed"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "vcpu.#"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_instance.testacc_instance", "vcpu.0.manufacturer"),
 				),
 			},
 		},

--- a/website/docs/d/is_dedicated_host.html.markdown
+++ b/website/docs/d/is_dedicated_host.html.markdown
@@ -47,6 +47,7 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `available_vcpu`:
   - `architecture` -  (String) The `VCPU` architecture.
+  - `manufacturer` -  (String) The `VCPU` manufacturer.
   - `count` -  (String) The number of `VCPUs` assigned.
 - `created_at` -  (String) The date and time that the dedicated host was created.
 - `crn` -  (String) The CRN for this dedicated host.
@@ -112,5 +113,6 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `vcpu`:
   - `architecture` -  (String) The `VCPU` architecture.
+  - `manufacturer` -  (String) The `VCPU` manufacturer.
   - `count` -  (String) The number of `VCPUs` assigned.
 - `zone` -  (String) The globally unique name of the zone this dedicated host resides in.

--- a/website/docs/d/is_dedicated_host_profile.html.markdown
+++ b/website/docs/d/is_dedicated_host_profile.html.markdown
@@ -105,3 +105,8 @@ In addition to all argument reference list, you can access the following attribu
   - `type`-  (String) The type for this profile field.
   - `value`-  (String) The value for this profile field.
   - `values`-  (String) The permitted values for this profile field.
+- `vcpu_manufacturer`-  (List) Nested `vcpu_manufacturer` blocks have the following structure.
+
+  Nested scheme for `vcpu_manufacturer`:
+  - `type`-  (String) The type for this profile field.
+  - `value`-  (String) The `VCPU` manufacturer for a dedicated host with this profile.

--- a/website/docs/d/is_dedicated_host_profiles.html.markdown
+++ b/website/docs/d/is_dedicated_host_profiles.html.markdown
@@ -101,5 +101,10 @@ Review the argument references that you can specify for your data source.
 	  - `type` - (String) The type for this profile field.
 	  - `value` - (String) The value for this profile field.
 	  - `values` - (String) The permitted values for this profile field.
+	- `vcpu_manufacturer` - (List)  Nested `vcpu_manufacturer` blocks have the following structure:
+
+	  Nested scheme for `vcpu_manufacturer`:
+	  - `type` - (String) The type for this profile field.
+	  - `value` - (String) The VCPU manufacturer for a dedicated host with this profile.
 - `total_count` - (String) The total number of resources across all pages.
 

--- a/website/docs/d/is_instance.html.markdown
+++ b/website/docs/d/is_instance.html.markdown
@@ -215,6 +215,7 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `vcpu`:
   - `architecture` - (String) The architecture of the virtual CPU.
+  - `manufacturer` - (String) The manufacturer of the virtual CPU.
   - `count`- (Integer) The number of virtual CPUs that are allocated to the instance.
 - `volume_attachments`- (List) A list of volume attachments that were created for the instance. 
 

--- a/website/docs/d/is_instance_profile.html.markdown
+++ b/website/docs/d/is_instance_profile.html.markdown
@@ -154,3 +154,9 @@ In addition to the argument reference list, you can access the following attribu
   - `type` - (String) The type for this profile field.
   - `value` - (String) The value for this profile field.
   - `values` - (String) The permitted values for this profile field.
+- `vcpu_manufacturer` - (List) Nested `vcpu_manufacturer` blocks have the following structure:
+
+  Nested scheme for `vcpu_manufacturer`:
+  - `default` - (String) The default VCPU manufacturer for an instance with this profile.
+  - `type` - (String) The type for this profile field.
+  - `value` - (String) The VCPU manufacturer for an instance with this profile.

--- a/website/docs/d/is_instance_profiles.html.markdown
+++ b/website/docs/d/is_instance_profiles.html.markdown
@@ -156,3 +156,9 @@ You can access the following attribute references after your data source is crea
       - `type` - (String) The type for this profile field.
       - `value` - (String) The value for this profile field.
       - `values` - (String) The permitted values for this profile field.
+  - `vcpu_manufacturer` - (List) Nested `vcpu_manufacturer` blocks have the following structure:
+
+    Nested scheme for `vcpu_manufacturer`:
+    - `default` - (String) The default VCPU manufacturer for an instance with this profile.
+    - `type` - (String) The type for this profile field.
+    - `value` - (String) The VCPU manufacturer for an instance with this profile.

--- a/website/docs/d/is_instances.html.markdown
+++ b/website/docs/d/is_instances.html.markdown
@@ -176,6 +176,7 @@ In addition to all argument reference list, you can access the following attribu
 
 	  Nested scheme for `vcpu`:
 		- `architecture` - (String) The architecture of the virtual CPU.
+		- `manufacturer` - (String) The manufacturer of the virtual CPU.
 		- `count`- (Integer) The number of virtual CPUs that are allocated to the instance.
 	- `vpc` - (String) The ID of the VPC that the instance belongs to.
 	- `zone` - (String) The zone where the instance was created.

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -633,6 +633,7 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `vcpu`:
   - `architecture` - (String) The architecture of the CPU.
   - `count`- (Integer) The number of virtual CPUS that are assigned to the instance.
+  - `manufacturer`- (String) The VCPU manufacturer.
 
 
 ## Import


### PR DESCRIPTION
```
resource "ibm_is_vpc" "vpc2" {
	  name = "sunitha-vpc-tfp"
	}
	
	resource "ibm_is_subnet" "subnet2" {
	  name            = "sunitha-subnet-tfp"
	  vpc             = ibm_is_vpc.vpc2.id
	  zone            = "us-south-2"
	  ipv4_cidr_block = "10.240.64.0/28"
	}
	
	resource "ibm_is_ssh_key" "sshkey" {
	  name       = "sunitha-subnet-tfp"
	  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCkF5mR1NqO7z6wviLUY2JZAWcEBhOmYi8lNlrLKP1mI4XOLUFq5KeIy5Ta14wqQR/W2dA72E51ummWn+39z9vgWgYKY5yIuVYy6b2W5Mo2MM73iEi1mB+GgqXWRTGRFBAPgT5mnqiwPZE0yKvQAe5vLPx6z4BxWKNi5Tp31Hf0KKHLKzrH4zUGSyoEFFYeoxUO8YSc6oyAKhJQBQAFXl0u9YSnuyiXUqYDpa06w0PUl2M6ALBTVa1uLmacTIJxJhJzDJxidW3fIVO9Nm7RSU0WcS2FGyqP3jNQKLAhpqUyDOyWfV/2yjy/H4Y3gjfLKCIhZIjUVO1KJlWcSScoJo7ILPWnzmr0uWmC/4qrqU0I3+8/AdBvJF1xCpzDBb/nPKWT2m8s5ZyahpmP4F91K6J0Zk3KLWzXkFrrB4MBpW9LLitPmgFhBitGKmD+Y2w93F3SvdzeLG4MlXg6RBSEJCFdWC9q+xPHxHg9TDkDVr6GoxOS/a/x8MLTHqnBhgczvxk= sunitha@Sunithas-MacBook-Pro.local"
	}
	
	resource "ibm_is_instance_template" "instancetemplate1" {
	   name    = "sunitha-instance-template"
	   image   = "r006-14140f94-fcc4-11e9-96e7-a72723715315"
	   profile = "bx2-8x32"
	
	   primary_network_interface {
		 subnet = ibm_is_subnet.subnet2.id
	   }
	
	   vpc       = ibm_is_vpc.vpc2.id
	   zone      = "us-south-2"
	   keys      = [ibm_is_ssh_key.sshkey.id]
	}
		
	resource "ibm_is_instance_group" "instance_group" {
		name =  "sunitha-instance-group"
		instance_template = ibm_is_instance_template.instancetemplate1.id
		instance_count =  1
		subnets = [ibm_is_subnet.subnet2.id]
	}

	resource "ibm_is_instance_group_manager" "instance_group_manager" {
		name = "sunitha-instance-group-manager"
		aggregation_window = 120
		instance_group = ibm_is_instance_group.instance_group.id
		cooldown = 300
		manager_type = "autoscale"
		enable_manager = true
		max_membership_count = 2
		min_membership_count = 1
	}
	
	resource "ibm_is_instance_group_manager_policy" "cpuPolicy" {
		instance_group = ibm_is_instance_group.instance_group.id
		instance_group_manager =  ibm_is_instance_group_manager.instance_group_manager.manager_id
		metric_type = "cpu"
		metric_value = 70
		policy_type = "target"
		name = "sunitha-instance-group-manager-policy-1"
	}
```
<img width="916" alt="Screenshot 2023-06-20 at 11 28 28 AM" src="https://github.com/IBM-Cloud/terraform-provider-ibm/assets/127872893/44274d1e-91fb-42f9-ab16-9b29f78f9b04">

<img width="682" alt="Screenshot 2023-06-20 at 11 29 05 AM" src="https://github.com/IBM-Cloud/terraform-provider-ibm/assets/127872893/f6b1c8e5-fc14-4593-beb8-c813e13f2daa">



