### PR TITLE
Deprecated match_resource_types and Introduced match_resource_type

### DIFF
--- a/website/docs/r/is_backup_policy.html.markdown
+++ b/website/docs/r/is_backup_policy.html.markdown
@@ -36,6 +36,10 @@ resource "ibm_is_backup_policy" "example" {
 Review the argument reference that you can specify for your resource.
 
 - `match_resource_types` - (Optional, List) A resource type this backup policy applies to. Resources that have both a matching type and a matching user tag will be subject to the backup policy. The default value is `["volume"]`.
+  
+~> **Note**
+  `match_resource_types` is deprecated. Please use `match_resource_type` instead.
+- `match_resource_type` - (Optional, String) The resource type this backup policy will apply to. Resources that have both a matching type and a matching user tag will be subject to the backup policy. The default value is `["volume"]`.
 - `match_user_tags` - (Required, List) The user tags this backup policy applies to. Resources that have both a matching user tag and a matching type will be subject to the backup policy.
 - `name` - (Required, String) The user-defined name for this backup policy. Names must be unique within the region this backup policy resides in. 
 - `resource_group` - (Optional, List) The resource group id, to use. If unspecified, the account's [default resource group](https://cloud.ibm.com/apidocs/resource-manager#introduction) is used.


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes #0000

Output from testing:

```
resource "ibm_is_backup_policy" "is_backup_policy" {
  match_user_tags = ["tag-0"]
  name            = "sunitha-terraform-baas"
}

resource "ibm_is_backup_policy" "is_backup_policy1" {
  match_user_tags = ["tag-0"] 
  match_resource_type = "volume"
  name            = "sunitha-terraform-baas1" 
} 
data "ibm_is_backup_policies" "is_backup_policies" {
}
```
<img width="1154" alt="Screenshot 2023-10-10 at 11 29 05 AM" src="https://github.com/IBM-Cloud/terraform-provider-ibm/assets/127872893/e9f033ec-ed44-404e-89ff-704480e79e60">

<img width="1187" alt="Screenshot 2023-10-10 at 11 29 22 AM" src="https://github.com/IBM-Cloud/terraform-provider-ibm/assets/127872893/0e9686d1-0398-444f-9f68-09aadc7b4381">
