### PR TITLE
added force_delete for dns bindings

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpc_dns_resolution_binding_test.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_dns_resolution_binding_test.go
@@ -39,7 +39,273 @@ func TestAccIBMIsVPCDnsResolutionBindingResourceBasic(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMIsVPCDnsResolutionBindingResourceForceDelete(t *testing.T) {
+	name1 := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
+	name2 := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
+	subnet1 := fmt.Sprintf("terraformsubnet-%d", acctest.RandIntRange(10, 100))
+	subnet2 := fmt.Sprintf("terraformsubnet-%d", acctest.RandIntRange(10, 100))
+	subnet3 := fmt.Sprintf("terraformsubnet-%d", acctest.RandIntRange(10, 100))
+	subnet4 := fmt.Sprintf("terraformsubnet-%d", acctest.RandIntRange(10, 100))
+	resourecinstance := fmt.Sprintf("terraformresource-%d", acctest.RandIntRange(10, 100))
+	resolver1 := fmt.Sprintf("terraformresolver-%d", acctest.RandIntRange(10, 100))
+	resolver2 := fmt.Sprintf("terraformresolver-%d", acctest.RandIntRange(10, 100))
+	binding := fmt.Sprintf("terraformbinding-%d", acctest.RandIntRange(10, 100))
+	enableHubTrue := true
+	enableHubFalse := false
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { acc.TestAccPreCheck(t) },
+		Providers: acc.TestAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckIBMIsVPCDnsResolutionBindingForceDeleteResourceConfig(name1, name2, subnet1, subnet2, subnet3, subnet4, resourecinstance, resolver1, resolver2, binding, enableHubTrue, enableHubFalse),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "id"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "vpc_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "href"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "name"),
+					resource.TestCheckResourceAttr("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "name", binding),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "vpc.#"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "name", name2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "dns.0.enable_hub", fmt.Sprintf("%t", enableHubTrue)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "dns.0.resolver.0.type", "system"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.enable_hub", fmt.Sprintf("%t", enableHubFalse)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolver.0.type", "system"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckIBMIsVPCDnsResolutionBindingForceDeleteUpdateResourceConfig(name1, name2, subnet1, subnet2, subnet3, subnet4, resourecinstance, resolver1, resolver2, binding, enableHubTrue, enableHubFalse),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "id"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "vpc_id"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "created_at"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "href"),
+					resource.TestCheckResourceAttr("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "name", binding),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "lifecycle_state"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "name"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "resource_type"),
+					resource.TestCheckResourceAttrSet("ibm_is_vpc_dns_resolution_binding.is_vpc_dns_resolution_binding", "vpc.#"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "name", name2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "dns.0.resolution_binding_count", "1"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "dns.0.enable_hub", fmt.Sprintf("%t", enableHubTrue)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_true", "dns.0.resolver.0.type", "system"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.enable_hub", fmt.Sprintf("%t", enableHubFalse)),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolver.0.type", "delegated"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.hub_false_delegated", "dns.0.resolution_binding_count", "1"),
+				),
+			},
+		},
+	})
+}
 
+func testAccCheckIBMIsVPCDnsResolutionBindingForceDeleteResourceConfig(vpcname, vpcname2, subnetname1, subnetname2, subnetname3, subnetname4, resourceinstance, resolver1, resolver2, bindingname string, enableHub, enablehubfalse bool) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "rg" {
+		is_default	   =  true
+	}
+	
+	resource ibm_is_vpc hub_true {
+		name = "%s"
+		dns {
+			enable_hub = %t
+		}
+	}
+	
+	resource ibm_is_vpc hub_false_delegated {
+		name = "%s"
+		dns {
+			enable_hub = %t
+		}
+	}
+	
+	resource "ibm_is_subnet" "hub_true_sub1" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_true.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_is_subnet" "hub_true_sub2" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_true.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_is_subnet" "hub_false_delegated_sub1" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_false_delegated.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_is_subnet" "hub_false_delegated_sub2" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_false_delegated.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_resource_instance" "dns-cr-instance" {
+		name		   		=  "%s"
+		resource_group_id  	=  data.ibm_resource_group.rg.id
+		location           	=  "global"
+		service		   		=  "dns-svcs"
+		plan		   		=  "standard-dns"
+	}
+	resource "ibm_dns_custom_resolver" "test_hub_true" {
+		name		   		=  "%s"
+		instance_id 	   	=  ibm_resource_instance.dns-cr-instance.guid
+		description	   		=  "new test CR - TF"
+		high_availability  	=  true
+		enabled 	   		=  true
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_true_sub1.crn
+				enabled	 = true
+		}
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_true_sub2.crn
+				enabled	 = true
+		}
+	}
+	resource "ibm_dns_custom_resolver" "test_hub_false_delegated" {
+		name		   		=  "%s"
+		instance_id 	   	=  ibm_resource_instance.dns-cr-instance.guid
+		description	   		=  "new test CR - TF"
+		high_availability  	=  true
+		enabled 	   		=  true
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_false_delegated_sub1.crn
+				enabled	 = true
+		}
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_false_delegated_sub2.crn
+				enabled	 = true
+		}
+	}
+	
+	resource ibm_is_vpc_dns_resolution_binding is_vpc_dns_resolution_binding {
+		name = "%s"
+		vpc_id=  ibm_is_vpc.hub_false_delegated.id
+		vpc {
+			id = ibm_is_vpc.hub_true.id
+		}
+		force_delete = true
+	}
+	`, vpcname, enableHub, vpcname2, enablehubfalse, subnetname1, acc.ISZoneName, subnetname2, acc.ISZoneName, subnetname3, acc.ISZoneName, subnetname4, acc.ISZoneName, resourceinstance, resolver1, resolver2, bindingname)
+}
+func testAccCheckIBMIsVPCDnsResolutionBindingForceDeleteUpdateResourceConfig(vpcname, vpcname2, subnetname1, subnetname2, subnetname3, subnetname4, resourceinstance, resolver1, resolver2, bindingname string, enableHub, enablehubfalse bool) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "rg" {
+		is_default	   =  true
+	}
+	
+	resource ibm_is_vpc hub_true {
+		name = "%s"
+		dns {
+			enable_hub = %t
+		}
+	}
+	
+	resource ibm_is_vpc hub_false_delegated {
+		name = "%s"
+		dns {
+			enable_hub = %t
+			resolver {
+				type = "delegated"
+				vpc_id = ibm_is_vpc.hub_true.id
+			}
+		}
+	}
+	
+	resource "ibm_is_subnet" "hub_true_sub1" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_true.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_is_subnet" "hub_true_sub2" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_true.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_is_subnet" "hub_false_delegated_sub1" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_false_delegated.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_is_subnet" "hub_false_delegated_sub2" {
+		name		   				=  "%s"
+		vpc      	   				=  ibm_is_vpc.hub_false_delegated.id
+		zone		   				=  "%s"
+		total_ipv4_address_count 	= 16
+	}
+	resource "ibm_resource_instance" "dns-cr-instance" {
+		name		   		=  "%s"
+		resource_group_id  	=  data.ibm_resource_group.rg.id
+		location           	=  "global"
+		service		   		=  "dns-svcs"
+		plan		   		=  "standard-dns"
+	}
+	resource "ibm_dns_custom_resolver" "test_hub_true" {
+		name		   		=  "%s"
+		instance_id 	   	=  ibm_resource_instance.dns-cr-instance.guid
+		description	   		=  "new test CR - TF"
+		high_availability  	=  true
+		enabled 	   		=  true
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_true_sub1.crn
+				enabled	 = true
+		}
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_true_sub2.crn
+				enabled	 = true
+		}
+	}
+	resource "ibm_dns_custom_resolver" "test_hub_false_delegated" {
+		name		   		=  "%s"
+		instance_id 	   	=  ibm_resource_instance.dns-cr-instance.guid
+		description	   		=  "new test CR - TF"
+		high_availability  	=  true
+		enabled 	   		=  true
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_false_delegated_sub1.crn
+				enabled	 = true
+		}
+		locations {
+				subnet_crn  = ibm_is_subnet.hub_false_delegated_sub2.crn
+				enabled	 = true
+		}
+	}
+	
+	resource ibm_is_vpc_dns_resolution_binding is_vpc_dns_resolution_binding {
+		name = "%s"
+		vpc_id=  ibm_is_vpc.hub_false_delegated.id
+		vpc {
+			id = ibm_is_vpc.hub_true.id
+		}
+		force_delete = true
+	}
+	
+	`, vpcname, enableHub, vpcname2, enablehubfalse, subnetname1, acc.ISZoneName, subnetname2, acc.ISZoneName, subnetname3, acc.ISZoneName, subnetname4, acc.ISZoneName, resourceinstance, resolver1, resolver2, bindingname)
+
+}
 func testAccCheckIBMIsVPCDnsResolutionBindingResourceConfigBasic(vpcname1, vpcname2, bindingname string, enablehub1, enablehub2 bool) string {
 	return fmt.Sprintf(`
 	resource ibm_is_vpc testacc_vpc1 {

--- a/website/docs/r/is_vpc_dns_resolution_binding.html.markdown
+++ b/website/docs/r/is_vpc_dns_resolution_binding.html.markdown
@@ -43,6 +43,7 @@ resource "ibm_is_vpc_dns_resolution_binding" "is_vpc_dns_resolution_binding_href
 Review the argument reference that you can specify for your data source.
 
 - `name` - (Optional, String) The DNS resolution binding name.
+- `force_delete` - (Optional, Bool) If you want to forcefully delete the dns binding when dns.resolver.type is set to delegated on the vpc. This will produce changes on the vpc.
 - `vpc_id` - (Required, Forces new resource, String) The VPC identifier of the source vpc.
 - `vpc` - (Required, Forces new resource, String) The VPC identifier/href/crn of the target.
 	Nested scheme for **vpc**:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMIsVPCDnsResolutionBindingResourceForceDelete
--- PASS: TestAccIBMIsVPCDnsResolutionBindingResourceForceDelete (416.88s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     418.949s
```
