### PR TITLE
fixed resource group issue on vni

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_virtual_network_interface.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_network_interface.go
@@ -385,12 +385,11 @@ func resourceIBMIsVirtualNetworkInterfaceCreate(context context.Context, d *sche
 		}
 		createVirtualNetworkInterfaceOptions.SetPrimaryIP(primaryIPModel)
 	}
-	if _, ok := d.GetOk("resource_group"); ok {
-		resourceGroupModel, err := resourceIBMIsVirtualNetworkInterfaceMapToVirtualNetworkInterfacePrototypeResourceGroup(d.Get("resource_group.0").(map[string]interface{}))
-		if err != nil {
-			return diag.FromErr(err)
+	if rgOk, ok := d.GetOk("resource_group"); ok {
+		rg := rgOk.(string)
+		createVirtualNetworkInterfaceOptions.ResourceGroup = &vpcv1.ResourceGroupIdentity{
+			ID: &rg,
 		}
-		createVirtualNetworkInterfaceOptions.SetResourceGroup(resourceGroupModel)
 	}
 	if _, ok := d.GetOk("security_groups"); ok {
 		var securityGroups []vpcv1.SecurityGroupIdentityIntf
@@ -857,14 +856,6 @@ func resourceIBMIsVirtualNetworkInterfaceMapToVirtualNetworkInterfacePrimaryIPRe
 	model.AutoDelete = core.BoolPtr(autodelete)
 	if modelMap["name"] != nil && modelMap["name"].(string) != "" {
 		model.Name = core.StringPtr(modelMap["name"].(string))
-	}
-	return model, nil
-}
-
-func resourceIBMIsVirtualNetworkInterfaceMapToVirtualNetworkInterfacePrototypeResourceGroup(modelMap map[string]interface{}) (vpcv1.ResourceGroupIdentityIntf, error) {
-	model := &vpcv1.ResourceGroupIdentity{}
-	if modelMap["id"] != nil && modelMap["id"].(string) != "" {
-		model.ID = core.StringPtr(modelMap["id"].(string))
 	}
 	return model, nil
 }

--- a/website/docs/r/is_virtual_network_interface.html.markdown
+++ b/website/docs/r/is_virtual_network_interface.html.markdown
@@ -45,7 +45,7 @@ You can specify the following arguments for this resource.
 	- `reserved_ip` - (Required, String) The unique identifier for this reserved IP.
 	- `name` - (Required, String) The name for this reserved IP. The name is unique across all reserved IPs in a subnet.
 	- `resource_type` - (Computed, String) The resource type.
-- `resource_group` - (Optional, List) The resource group id for this virtual network interface.
+- `resource_group` - (Optional, String) The resource group id for this virtual network interface.
 - `security_groups` - (Optional, Array of string) The security group ids list for this virtual network interface.
 - `subnet` - (Optional, List) The associated subnet id.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMIsVirtualNetworkInterfaceResourceGroup
--- PASS: TestAccIBMIsVirtualNetworkInterfaceResourceGroup (101.87s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     105.566s
```
