### PR TITLE
VPN Server Delete wait logic changes

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpn_server.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_server.go
@@ -1027,9 +1027,9 @@ func isWaitForVPNServerDeleted(context context.Context, sess *vpcv1.VpcV1, d *sc
 				if response != nil && response.StatusCode == 404 {
 					return vpnServer, isVPNServerStatusDeleted, nil
 				}
-				return vpnServer, isVPNServerStatusDeleting, fmt.Errorf("The VPC route %s failed to delete: %s\n%s", d.Id(), err, response)
+				return vpnServer, *vpnServer.LifecycleState, fmt.Errorf("The VPC vpn server %s failed to delete: %s\n%s", d.Id(), err, response)
 			}
-			return vpnServer, isVPNServerStatusDeleting, nil
+			return vpnServer, *vpnServer.LifecycleState, nil
 
 		},
 		Timeout:    d.Timeout(schema.TimeoutDelete),

--- a/ibm/service/vpc/resource_ibm_is_vpn_server_route.go
+++ b/ibm/service/vpc/resource_ibm_is_vpn_server_route.go
@@ -422,9 +422,9 @@ func isWaitForVPNServerRouteDeleted(context context.Context, sess *vpcv1.VpcV1, 
 				if response != nil && response.StatusCode == 404 {
 					return vpnServerRoute, isVPNServerRouteStatusDeleted, nil
 				}
-				return vpnServerRoute, isVPNServerRouteStatusDeleting, fmt.Errorf("The VPC route %s failed to delete: %s\n%s", d.Id(), err, response)
+				return vpnServerRoute, *vpnServerRoute.LifecycleState, fmt.Errorf("The VPC route %s failed to delete: %s\n%s", d.Id(), err, response)
 			}
-			return vpnServerRoute, isVPNServerRouteStatusDeleting, nil
+			return vpnServerRoute, *vpnServerRoute.LifecycleState, nil
 
 		},
 		Timeout:    d.Timeout(schema.TimeoutDelete),


### PR DESCRIPTION
```
resource "ibm_is_vpn_server" "is_vpn_server" {
  certificate_crn = "crn:v1:bluemix:public:secrets-manager:us-south:a/7f75c7b025e54bc5635f754b2f888665:0d7981e7-b381-424e-a3c7-0af38f471d87:secret:cdcee4c3-4558-ed20-2bc0-3df0a93af2aa"
  client_authentication {
    method        = "certificate"
    client_ca_crn = "crn:v1:bluemix:public:secrets-manager:us-south:a/7f75c7b025e54bc5635f754b2f888665:0d7981e7-b381-424e-a3c7-0af38f471d87:secret:c329a9cd-08dc-bcae-b42b-bc8b0927562a"
  }
  client_ip_pool         = "192.167.0.0/16"
  enable_split_tunneling = true
  name                   = "sunitha-vpn-server"
  port                   = 443
  protocol               = "tcp"
  subnets                = ["0727-5adc42b5-fcba-4f12-9c36-e15d305c919e"]
  security_groups        = ["r006-a4281eaa-023b-41bb-8060-247eb0bb5e68"]
}
resource "ibm_is_vpn_server_route" "is_vpn_server_route" {
  vpn_server  = ibm_is_vpn_server.is_vpn_server.id
  destination = "172.16.0.0/16"
  action      = "translate"
  name        = "sunitha-vpn-server-route"
}
```
<img width="1199" alt="Screenshot 2023-12-29 at 11 28 59 PM" src="https://github.com/ibm-vpc/terraform-provider-ibm/assets/127872893/cb515dab-3308-4914-8db5-1d8e63241291">
