### PR TITLE
Added a empty string check on ips for endpoint gateway resource

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -622,9 +622,13 @@ func expandIPs(ipsSet []interface{}) (ipsOptions []vpcv1.EndpointGatewayReserved
 		}
 
 		ipsOpt := &vpcv1.EndpointGatewayReservedIP{
-			ID:     core.StringPtr(ipsID),
-			Name:   core.StringPtr(ipsName),
 			Subnet: ipsSubnetOpt,
+		}
+		if ipsID != "" {
+			ipsOpt.ID = &ipsID
+		}
+		if ipsName != "" {
+			ipsOpt.Name = &ipsName
 		}
 		ipsOptions = append(ipsOptions, ipsOpt)
 	}

--- a/website/docs/r/is_virtual_endpoint_gateway.html.markdown
+++ b/website/docs/r/is_virtual_endpoint_gateway.html.markdown
@@ -95,11 +95,11 @@ Review the argument references that you can specify for your resource.
 - `ips`  (Optional, List) The reserved IPs to bind to this endpoint gateway. At most one reserved IP per zone is allowed.
 
   Nested scheme for `ips`:
-  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**address**, **name**. **subnet**)
+  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**name**,  **subnet**)
   - `name` - (Optional, String) The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with ibm- are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
   - `subnet` - (Optional, String) The subnet in which to create this reserved IP.
   
-  ~> **NOTE:** `id` and `subnet` are mutually exclusive.
+  ~> **NOTE:** `id` and (`name`, `subnet`) are mutually exclusive.
 
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID.
 - `security_groups` - (Optional, list) The security groups to use for this endpoint gateway. If unspecified, the VPC's default security group is used.

--- a/website/docs/r/is_virtual_endpoint_gateway.html.markdown
+++ b/website/docs/r/is_virtual_endpoint_gateway.html.markdown
@@ -92,12 +92,12 @@ Review the argument references that you can specify for your resource.
     -> **NOTE:** `allow_dns_resolution_binding` is a select location availability, invitation only feature. If used in other regions may lead to inconsistencies in state management.
 - `allow_dns_resolution_binding` - (Optional, bool) Indicates whether to allow this endpoint gateway to participate in DNS resolution bindings with a VPC that has dns.enable_hub set to true.
 - `name` - (Required, Forces new resource, String) The endpoint gateway name.
-- `ips`  (Optional, List) The endpoint gateway resource group.
+- `ips`  (Optional, List) The reserved IPs to bind to this endpoint gateway. At most one reserved IP per zone is allowed.
 
   Nested scheme for `ips`:
-  - `id` - (Optional, String) The endpoint gateway resource group IPs ID.
-  - `name` - (Optional, String) The endpoint gateway resource group IPs name.
-  - `subnet` - (Optional, String) The endpoint gateway resource group subnet ID.
+  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**address**, **name**. **subnet**)
+  - `name` - (Optional, String) The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with ibm- are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
+  - `subnet` - (Optional, String) The subnet in which to create this reserved IP.
   
   ~> **NOTE:** `id` and `subnet` are mutually exclusive.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVirtualEndpointGateway_OptionalName'
=== RUN   TestAccIBMISVirtualEndpointGateway_OptionalName
--- PASS: TestAccIBMISVirtualEndpointGateway_OptionalName (110.38s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     112.168s
```
