### PR TITLE
added support for address in endpoint gateways ips

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -622,9 +622,13 @@ func expandIPs(ipsSet []interface{}) (ipsOptions []vpcv1.EndpointGatewayReserved
 		}
 
 		ipsOpt := &vpcv1.EndpointGatewayReservedIP{
-			ID:     core.StringPtr(ipsID),
-			Name:   core.StringPtr(ipsName),
 			Subnet: ipsSubnetOpt,
+		}
+		if ipsID != "" {
+			ipsOpt.ID = &ipsID
+		}
+		if ipsName != "" {
+			ipsOpt.Name = &ipsName
 		}
 		ipsOptions = append(ipsOptions, ipsOpt)
 	}

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -162,6 +162,7 @@ func ResourceIBMISEndpointGateway() *schema.Resource {
 						},
 						isVirtualEndpointGatewayIPsAddress: {
 							Type:        schema.TypeString,
+							Optional:    true,
 							Computed:    true,
 							Description: "The IP Address",
 						},
@@ -613,6 +614,7 @@ func expandIPs(ipsSet []interface{}) (ipsOptions []vpcv1.EndpointGatewayReserved
 		// IPs option
 		ipsID := ips[isVirtualEndpointGatewayIPsID].(string)
 		ipsName := ips[isVirtualEndpointGatewayIPsName].(string)
+		ipsAddress := ips[isVirtualEndpointGatewayIPsAddress].(string)
 
 		// IPs subnet option
 		ipsSubnetID := ips[isVirtualEndpointGatewayIPsSubnet].(string)
@@ -629,6 +631,9 @@ func expandIPs(ipsSet []interface{}) (ipsOptions []vpcv1.EndpointGatewayReserved
 		}
 		if ipsName != "" {
 			ipsOpt.Name = &ipsName
+		}
+		if ipsAddress != "" {
+			ipsOpt.Address = &ipsAddress
 		}
 		ipsOptions = append(ipsOptions, ipsOpt)
 	}

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -508,6 +508,8 @@ func resourceIBMisVirtualEndpointGatewayRead(d *schema.ResourceData, meta interf
 		flattenEndpointGatewayTarget(endpointGateway.Target.(*vpcv1.EndpointGatewayTarget)))
 	if len(endpointGateway.ServiceEndpoints) > 0 {
 		d.Set(isVirtualEndpointGatewayServiceEndpoints, endpointGateway.ServiceEndpoints)
+	} else {
+		d.Set(isVirtualEndpointGatewayServiceEndpoints, []string{})
 	}
 	d.Set(isVirtualEndpointGatewayVpcID, endpointGateway.VPC.ID)
 	if endpointGateway.SecurityGroups != nil {

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway.go
@@ -508,8 +508,6 @@ func resourceIBMisVirtualEndpointGatewayRead(d *schema.ResourceData, meta interf
 		flattenEndpointGatewayTarget(endpointGateway.Target.(*vpcv1.EndpointGatewayTarget)))
 	if len(endpointGateway.ServiceEndpoints) > 0 {
 		d.Set(isVirtualEndpointGatewayServiceEndpoints, endpointGateway.ServiceEndpoints)
-	} else {
-		d.Set(isVirtualEndpointGatewayServiceEndpoints, []string{})
 	}
 	d.Set(isVirtualEndpointGatewayVpcID, endpointGateway.VPC.ID)
 	if endpointGateway.SecurityGroups != nil {

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway_test.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway_test.go
@@ -212,7 +212,6 @@ func TestAccIBMISVirtualEndpointGateway_IpsAddress(t *testing.T) {
 					resource.TestCheckResourceAttrSet(name, "ips.#"),
 					resource.TestCheckResourceAttrSet(name, "ips.0.name"),
 					resource.TestCheckResourceAttrSet(name, "ips.0.address"),
-					resource.TestCheckResourceAttrSet(name, "ips.0.subnet"),
 					resource.TestCheckResourceAttrSet(name, "target.#"),
 					resource.TestCheckResourceAttrSet(name, "created_at"),
 					resource.TestCheckResourceAttrSet(name, "crn"),

--- a/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway_test.go
+++ b/ibm/service/vpc/resource_ibm_is_virtual_endpoint_gateway_test.go
@@ -191,6 +191,40 @@ func TestAccIBMISVirtualEndpointGateway_OptionalName(t *testing.T) {
 		},
 	})
 }
+func TestAccIBMISVirtualEndpointGateway_IpsAddress(t *testing.T) {
+	var monitor string
+	vpcname1 := fmt.Sprintf("tfvpngw-vpc-%d", acctest.RandIntRange(10, 100))
+	subnetname1 := fmt.Sprintf("tfvpngw-subnet-%d", acctest.RandIntRange(10, 100))
+	name1 := fmt.Sprintf("tfvpngw-createname-%d", acctest.RandIntRange(10, 100))
+	name := "ibm_is_virtual_endpoint_gateway.endpoint_gateway"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckisVirtualEndpointGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				ExpectNonEmptyPlan: true,
+				Config:             testAccCheckisVirtualEndpointGatewayConfigIpsAddress(vpcname1, subnetname1, name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckisVirtualEndpointGatewayExists(name, &monitor),
+					resource.TestCheckResourceAttr(name, "name", name1),
+					resource.TestCheckResourceAttrSet(name, "ips.#"),
+					resource.TestCheckResourceAttrSet(name, "ips.0.name"),
+					resource.TestCheckResourceAttrSet(name, "ips.0.address"),
+					resource.TestCheckResourceAttrSet(name, "ips.0.subnet"),
+					resource.TestCheckResourceAttrSet(name, "target.#"),
+					resource.TestCheckResourceAttrSet(name, "created_at"),
+					resource.TestCheckResourceAttrSet(name, "crn"),
+					resource.TestCheckResourceAttr(name, "health_state", "ok"),
+					resource.TestCheckResourceAttr(name, "lifecycle_state", "stable"),
+					resource.TestCheckResourceAttrSet(name, "resource_group"),
+					resource.TestCheckResourceAttrSet(name, "resource_type"),
+				),
+			},
+		},
+	})
+}
 
 func TestAccIBMISVirtualEndpointGateway_CreateAfterManualDestroy(t *testing.T) {
 	t.Skip()
@@ -360,6 +394,37 @@ func testAccCheckisVirtualEndpointGatewayConfigOptionalName(vpcname1, subnetname
 		vpc = ibm_is_vpc.testacc_vpc.id
 		ips {
 		  subnet = ibm_is_subnet.testacc_subnet.id
+		}
+		resource_group = data.ibm_resource_group.test_acc.id
+	  }`, vpcname1, subnetname1, acc.ISZoneName, acc.ISCIDR, name1)
+}
+func testAccCheckisVirtualEndpointGatewayConfigIpsAddress(vpcname1, subnetname1, name1 string) string {
+	return fmt.Sprintf(`
+	data "ibm_resource_group" "test_acc" {
+		is_default = true
+	  }
+	  resource "ibm_is_vpc" "testacc_vpc" {
+		name           = "%[1]s"
+		resource_group = data.ibm_resource_group.test_acc.id
+	  }
+	  resource "ibm_is_subnet" "testacc_subnet" {
+		name            = "%[2]s"
+		vpc             = ibm_is_vpc.testacc_vpc.id
+		zone            = "%[3]s"
+		ipv4_cidr_block = "%[4]s"
+		resource_group  = data.ibm_resource_group.test_acc.id
+	  }
+	  resource "ibm_is_virtual_endpoint_gateway" "endpoint_gateway" {
+		name = "%[5]s"
+		target {
+		  name          = "ibm-dns-server2"
+		  resource_type = "provider_infrastructure_service"
+		}
+		vpc = ibm_is_vpc.testacc_vpc.id
+		ips {
+		  subnet 	= ibm_is_subnet.testacc_subnet.id
+		  name		= "test-egw-ip1"
+		  address 	= cidrhost(ibm_is_subnet.testacc_subnet.ipv4_cidr_block, 14)
 		}
 		resource_group = data.ibm_resource_group.test_acc.id
 	  }`, vpcname1, subnetname1, acc.ISZoneName, acc.ISCIDR, name1)

--- a/website/docs/r/is_virtual_endpoint_gateway.html.markdown
+++ b/website/docs/r/is_virtual_endpoint_gateway.html.markdown
@@ -95,11 +95,11 @@ Review the argument references that you can specify for your resource.
 - `ips`  (Optional, List) The reserved IPs to bind to this endpoint gateway. At most one reserved IP per zone is allowed.
 
   Nested scheme for `ips`:
-  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**address**, **name**. **subnet**)
+  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**name**,  **subnet**)
   - `name` - (Optional, String) The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with ibm- are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
   - `subnet` - (Optional, String) The subnet in which to create this reserved IP.
   
-  ~> **NOTE:** `id` and `subnet` are mutually exclusive.
+  ~> **NOTE:** `id` and (`name`, `subnet`) are mutually exclusive.
 
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID.
 - `security_groups` - (Optional, list) The security groups to use for this endpoint gateway. If unspecified, the VPC's default security group is used.

--- a/website/docs/r/is_virtual_endpoint_gateway.html.markdown
+++ b/website/docs/r/is_virtual_endpoint_gateway.html.markdown
@@ -95,11 +95,12 @@ Review the argument references that you can specify for your resource.
 - `ips`  (Optional, List) The reserved IPs to bind to this endpoint gateway. At most one reserved IP per zone is allowed.
 
   Nested scheme for `ips`:
-  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**name**,  **subnet**)
+  - `address` - (Optional, String) The IP address to reserve, which must not already be reserved on the subnet.
+  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**address**, **name**. **subnet**)
   - `name` - (Optional, String) The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with ibm- are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
   - `subnet` - (Optional, String) The subnet in which to create this reserved IP.
   
-  ~> **NOTE:** `id` and (`name`, `subnet`) are mutually exclusive.
+  ~> **NOTE:** `id` and (`address`, `name`, `subnet`) are mutually exclusive.
 
 - `resource_group` - (Optional, Forces new resource, String) The resource group ID.
 - `security_groups` - (Optional, list) The security groups to use for this endpoint gateway. If unspecified, the VPC's default security group is used.

--- a/website/docs/r/is_virtual_endpoint_gateway.html.markdown
+++ b/website/docs/r/is_virtual_endpoint_gateway.html.markdown
@@ -92,12 +92,12 @@ Review the argument references that you can specify for your resource.
     -> **NOTE:** `allow_dns_resolution_binding` is a select location availability, invitation only feature. If used in other regions may lead to inconsistencies in state management.
 - `allow_dns_resolution_binding` - (Optional, bool) Indicates whether to allow this endpoint gateway to participate in DNS resolution bindings with a VPC that has dns.enable_hub set to true.
 - `name` - (Required, Forces new resource, String) The endpoint gateway name.
-- `ips`  (Optional, List) The endpoint gateway resource group.
+- `ips`  (Optional, List) The reserved IPs to bind to this endpoint gateway. At most one reserved IP per zone is allowed.
 
   Nested scheme for `ips`:
-  - `id` - (Optional, String) The endpoint gateway resource group IPs ID.
-  - `name` - (Optional, String) The endpoint gateway resource group IPs name.
-  - `subnet` - (Optional, String) The endpoint gateway resource group subnet ID.
+  - `id` - (Optional, String) The unique identifier for this reserved IP. Conflicts with other properties (**address**, **name**. **subnet**)
+  - `name` - (Optional, String) The name for this reserved IP. The name must not be used by another reserved IP in the subnet. Names starting with ibm- are reserved for provider-owned resources, and are not allowed. If unspecified, the name will be a hyphenated list of randomly-selected words.
+  - `subnet` - (Optional, String) The subnet in which to create this reserved IP.
   
   ~> **NOTE:** `id` and `subnet` are mutually exclusive.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVirtualEndpointGateway_IpsAddress'
=== RUN   TestAccIBMISVirtualEndpointGateway_IpsAddress
--- PASS: TestAccIBMISVirtualEndpointGateway_IpsAddress (107.62s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     109.320s
```
