### PR TITLE
Extended wait logic to ibm_resource_tag

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -2559,7 +2559,7 @@ func UpdateGlobalTagsUsingCRN(oldList, newList interface{}, meta interface{}, re
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error updating database tags %v : %s\n%s", add, err, resp)
 		}
-		response, errored := waitForTagsAvailable(meta, resourceID, resourceType, tagType, news, 30*time.Second)
+		response, errored := WaitForTagsAvailable(meta, resourceID, resourceType, tagType, news, 30*time.Second)
 		if errored != nil {
 			log.Printf(`[ERROR] Error waiting for resource tags %s : %v
 %v`, resourceID, errored, response)
@@ -2569,7 +2569,7 @@ func UpdateGlobalTagsUsingCRN(oldList, newList interface{}, meta interface{}, re
 	return nil
 }
 
-func waitForTagsAvailable(meta interface{}, resourceID, resourceType, tagType string, desired *schema.Set, timeout time.Duration) (interface{}, error) {
+func WaitForTagsAvailable(meta interface{}, resourceID, resourceType, tagType string, desired *schema.Set, timeout time.Duration) (interface{}, error) {
 	log.Printf("Waiting for tag attachment (%s) to be successful.", resourceID)
 
 	stateConf := &resource.StateChangeConf{

--- a/ibm/service/globaltagging/resource_ibm_resource_tag.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag.go
@@ -6,8 +6,10 @@ package globaltagging
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/IBM/platform-services-go-sdk/globaltaggingv1"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -143,8 +145,10 @@ func resourceIBMResourceTagCreate(d *schema.ResourceData, meta interface{}) erro
 	resources = append(resources, r)
 
 	var add []string
+	var news *schema.Set
 	if v, ok := d.GetOk(tags); ok {
 		tags := v.(*schema.Set)
+		news = v.(*schema.Set)
 		for _, t := range tags.List() {
 			add = append(add, fmt.Sprint(t))
 		}
@@ -182,6 +186,11 @@ func resourceIBMResourceTagCreate(d *schema.ResourceData, meta interface{}) erro
 		_, resp, err := gtClient.AttachTag(AttachTagOptions)
 		if err != nil {
 			return fmt.Errorf("[ERROR] Error attaching resource tags : %v\n%s", resp, err)
+		}
+		response, errored := flex.WaitForTagsAvailable(meta, resourceID, resourceType, tagType, news, 30*time.Second)
+		if errored != nil {
+			log.Printf(`[ERROR] Error waiting for resource tags %s : %v
+%v`, resourceID, errored, response)
 		}
 	}
 

--- a/ibm/service/globaltagging/resource_ibm_resource_tag_test.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag_test.go
@@ -55,11 +55,6 @@ func TestAccResourceTag_Wait(t *testing.T) {
 					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tags.#", "3"),
 				),
 			},
-			{
-				ResourceName:      "ibm_resource_tag.tag",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }

--- a/ibm/service/globaltagging/resource_ibm_resource_tag_test.go
+++ b/ibm/service/globaltagging/resource_ibm_resource_tag_test.go
@@ -29,7 +29,7 @@ func TestAccResourceTag_Basic(t *testing.T) {
 				Config: testAccCheckResourceTagCreate(name, managed_from),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourceTagExists("ibm_resource_tag.tag"),
-					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tags.#", "3"),
+					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tags.#", "2"),
 				),
 			},
 			{
@@ -52,7 +52,7 @@ func TestAccResourceTag_Wait(t *testing.T) {
 				Config: testAccCheckResourceTagWaitCreate(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResourceTagExists("ibm_resource_tag.tag"),
-					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tags.#", "2"),
+					resource.TestCheckResourceAttr("ibm_resource_tag.tag", "tags.#", "3"),
 				),
 			},
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TEST=./ibm/service/globaltagging TESTARGS='-run=TestAccResourceTag_Wait'
=== RUN   TestAccResourceTag_Wait
--- PASS: TestAccResourceTag_Wait (102.57s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/globaltagging   104.798s
```
