### PR TITLE
fix(ins-keys): Make VSI keys optional

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -400,7 +400,7 @@ func ResourceIBMISInstance() *schema.Resource {
 							Optional:      true,
 							ForceNew:      true,
 							ConflictsWith: []string{"catalog_offering.0.version_crn"},
-							RequiredWith:  []string{isInstanceZone, isInstancePrimaryNetworkInterface, isInstanceKeys, isInstanceVPC, isInstanceProfile},
+							RequiredWith:  []string{isInstanceZone, isInstancePrimaryNetworkInterface, isInstanceVPC, isInstanceProfile},
 							Description:   "Identifies a catalog offering by a unique CRN property",
 						},
 						isInstanceCatalogOfferingVersionCrn: {
@@ -408,7 +408,7 @@ func ResourceIBMISInstance() *schema.Resource {
 							Optional:      true,
 							ForceNew:      true,
 							ConflictsWith: []string{"catalog_offering.0.offering_crn"},
-							RequiredWith:  []string{isInstanceZone, isInstancePrimaryNetworkInterface, isInstanceKeys, isInstanceVPC, isInstanceProfile},
+							RequiredWith:  []string{isInstanceZone, isInstancePrimaryNetworkInterface, isInstanceVPC, isInstanceProfile},
 							Description:   "Identifies a version of a catalog offering by a unique CRN property",
 						},
 						isInstanceCatalogOfferingPlanCrn: {
@@ -1143,7 +1143,7 @@ func ResourceIBMISInstance() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"boot_volume.0.snapshot", "boot_volume.0.snapshot_crn", "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn", "boot_volume.0.volume_id"},
 				AtLeastOneOf:  []string{isInstanceImage, isInstanceSourceTemplate, "boot_volume.0.snapshot", "boot_volume.0.snapshot_crn", "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn", "boot_volume.0.volume_id"},
-				RequiredWith:  []string{isInstanceZone, isInstanceKeys, isInstanceVPC, isInstanceProfile},
+				RequiredWith:  []string{isInstanceZone, isInstanceVPC, isInstanceProfile},
 				Description:   "image id",
 			},
 
@@ -1159,7 +1159,7 @@ func ResourceIBMISInstance() *schema.Resource {
 							Optional:      true,
 							ForceNew:      true,
 							Computed:      true,
-							RequiredWith:  []string{isInstanceZone, isInstanceProfile, isInstanceKeys, isInstanceVPC},
+							RequiredWith:  []string{isInstanceZone, isInstanceProfile, isInstanceVPC},
 							AtLeastOneOf:  []string{isInstanceImage, isInstanceSourceTemplate, "boot_volume.0.volume_id", "boot_volume.0.snapshot", "boot_volume.0.snapshot_crn", "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn"},
 							ConflictsWith: []string{isInstanceImage, isInstanceSourceTemplate, "boot_volume.0.snapshot", "boot_volume.0.snapshot_crn", "boot_volume.0.name", "boot_volume.0.encryption", "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn"},
 							Description:   "The unique identifier for this volume",
@@ -1179,7 +1179,7 @@ func ResourceIBMISInstance() *schema.Resource {
 
 						isInstanceVolumeSnapshot: {
 							Type:          schema.TypeString,
-							RequiredWith:  []string{isInstanceZone, isInstanceProfile, isInstanceKeys, isInstanceVPC},
+							RequiredWith:  []string{isInstanceZone, isInstanceProfile, isInstanceVPC},
 							AtLeastOneOf:  []string{isInstanceImage, isInstanceSourceTemplate, "boot_volume.0.snapshot", "boot_volume.0.snapshot_crn", "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn", "boot_volume.0.volume_id"},
 							ConflictsWith: []string{isInstanceImage, isInstanceSourceTemplate, "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn", "boot_volume.0.volume_id", "boot_volume.0.snapshot_crn"},
 							Optional:      true,
@@ -1188,7 +1188,7 @@ func ResourceIBMISInstance() *schema.Resource {
 						},
 						isInstanceVolumeSnapshotCrn: {
 							Type:          schema.TypeString,
-							RequiredWith:  []string{isInstanceZone, isInstanceProfile, isInstanceKeys, isInstanceVPC},
+							RequiredWith:  []string{isInstanceZone, isInstanceProfile, isInstanceVPC},
 							AtLeastOneOf:  []string{isInstanceImage, isInstanceSourceTemplate, "boot_volume.0.snapshot", "boot_volume.0.snapshot_crn", "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn", "boot_volume.0.volume_id"},
 							ConflictsWith: []string{isInstanceImage, isInstanceSourceTemplate, "catalog_offering.0.offering_crn", "catalog_offering.0.version_crn", "boot_volume.0.volume_id", "boot_volume.0.snapshot"},
 							Optional:      true,
@@ -2121,16 +2121,18 @@ func instanceCreateByImage(d *schema.ResourceData, meta interface{}, profile, na
 		instanceproto.NetworkInterfaces = intfs
 	}
 
-	keySet := d.Get(isInstanceKeys).(*schema.Set)
-	if keySet.Len() != 0 {
-		keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
-		for i, key := range keySet.List() {
-			keystr := key.(string)
-			keyobjs[i] = &vpcv1.KeyIdentity{
-				ID: &keystr,
+	if keySetIntf, ok := d.GetOk(isInstanceKeys); ok {
+		keySet := keySetIntf.(*schema.Set)
+		if keySet.Len() != 0 {
+			keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
+			for i, key := range keySet.List() {
+				keystr := key.(string)
+				keyobjs[i] = &vpcv1.KeyIdentity{
+					ID: &keystr,
+				}
 			}
+			instanceproto.Keys = keyobjs
 		}
-		instanceproto.Keys = keyobjs
 	}
 
 	if userdata, ok := d.GetOk(isInstanceUserData); ok {
@@ -2568,16 +2570,18 @@ func instanceCreateByCatalogOffering(d *schema.ResourceData, meta interface{}, p
 		instanceproto.NetworkInterfaces = intfs
 	}
 
-	keySet := d.Get(isInstanceKeys).(*schema.Set)
-	if keySet.Len() != 0 {
-		keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
-		for i, key := range keySet.List() {
-			keystr := key.(string)
-			keyobjs[i] = &vpcv1.KeyIdentity{
-				ID: &keystr,
+	if keySetIntf, ok := d.GetOk(isInstanceKeys); ok {
+		keySet := keySetIntf.(*schema.Set)
+		if keySet.Len() != 0 {
+			keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
+			for i, key := range keySet.List() {
+				keystr := key.(string)
+				keyobjs[i] = &vpcv1.KeyIdentity{
+					ID: &keystr,
+				}
 			}
+			instanceproto.Keys = keyobjs
 		}
-		instanceproto.Keys = keyobjs
 	}
 
 	if userdata, ok := d.GetOk(isInstanceUserData); ok {
@@ -2994,16 +2998,18 @@ func instanceCreateByTemplate(d *schema.ResourceData, meta interface{}, profile,
 		instanceproto.NetworkInterfaces = intfs
 	}
 
-	keySet := d.Get(isInstanceKeys).(*schema.Set)
-	if keySet.Len() != 0 {
-		keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
-		for i, key := range keySet.List() {
-			keystr := key.(string)
-			keyobjs[i] = &vpcv1.KeyIdentity{
-				ID: &keystr,
+	if keySetIntf, ok := d.GetOk(isInstanceKeys); ok {
+		keySet := keySetIntf.(*schema.Set)
+		if keySet.Len() != 0 {
+			keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
+			for i, key := range keySet.List() {
+				keystr := key.(string)
+				keyobjs[i] = &vpcv1.KeyIdentity{
+					ID: &keystr,
+				}
 			}
+			instanceproto.Keys = keyobjs
 		}
-		instanceproto.Keys = keyobjs
 	}
 
 	if userdata, ok := d.GetOk(isInstanceUserData); ok {
@@ -3427,16 +3433,18 @@ func instanceCreateBySnapshot(d *schema.ResourceData, meta interface{}, profile,
 		instanceproto.NetworkInterfaces = intfs
 	}
 
-	keySet := d.Get(isInstanceKeys).(*schema.Set)
-	if keySet.Len() != 0 {
-		keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
-		for i, key := range keySet.List() {
-			keystr := key.(string)
-			keyobjs[i] = &vpcv1.KeyIdentity{
-				ID: &keystr,
+	if keySetIntf, ok := d.GetOk(isInstanceKeys); ok {
+		keySet := keySetIntf.(*schema.Set)
+		if keySet.Len() != 0 {
+			keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
+			for i, key := range keySet.List() {
+				keystr := key.(string)
+				keyobjs[i] = &vpcv1.KeyIdentity{
+					ID: &keystr,
+				}
 			}
+			instanceproto.Keys = keyobjs
 		}
-		instanceproto.Keys = keyobjs
 	}
 
 	if userdata, ok := d.GetOk(isInstanceUserData); ok {
@@ -3826,16 +3834,18 @@ func instanceCreateByVolume(d *schema.ResourceData, meta interface{}, profile, n
 		instanceproto.NetworkInterfaces = intfs
 	}
 
-	keySet := d.Get(isInstanceKeys).(*schema.Set)
-	if keySet.Len() != 0 {
-		keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
-		for i, key := range keySet.List() {
-			keystr := key.(string)
-			keyobjs[i] = &vpcv1.KeyIdentity{
-				ID: &keystr,
+	if keySetIntf, ok := d.GetOk(isInstanceKeys); ok {
+		keySet := keySetIntf.(*schema.Set)
+		if keySet.Len() != 0 {
+			keyobjs := make([]vpcv1.KeyIdentityIntf, keySet.Len())
+			for i, key := range keySet.List() {
+				keystr := key.(string)
+				keyobjs[i] = &vpcv1.KeyIdentity{
+					ID: &keystr,
+				}
 			}
+			instanceproto.Keys = keyobjs
 		}
-		instanceproto.Keys = keyobjs
 	}
 
 	if userdata, ok := d.GetOk(isInstanceUserData); ok {

--- a/website/docs/r/is_instance.html.markdown
+++ b/website/docs/r/is_instance.html.markdown
@@ -567,8 +567,11 @@ Review the argument references that you can specify for your resource.
   
   ~> **Note:**
   `image` conflicts with `boot_volume.0.snapshot` and `catalog_offering`, not required when creating instance using `instance_template` or `catalog_offering`
-- `keys` - (Required, List) A comma-separated list of SSH keys that you want to add to your instance.
+- `keys` - (Optional, List) A comma-separated list of SSH keys that you want to add to your instance. The public SSH keys for the administrative user of the virtual server instance. Keys will be made available to the virtual server instance as cloud-init vendor data. For cloud-init enabled images, these keys will also be added as SSH authorized keys for the administrative user.
 
+  ~> **Note:**
+  For Windows images, the keys of type rsa must be specified, and one will be selected to encrypt the administrator password. Keys are optional for other images, but if no keys are specified, the instance will be inaccessible unless the specified image provides another means of access.
+  
   ~> **Note:**
   **&#x2022;** `ed25519` can only be used if the operating system supports this key type.</br>
   **&#x2022;** `ed25519` can't be used with Windows or VMware images.</br>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
