### PR TITLE
Vpc fix

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_vpc.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc.go
@@ -117,6 +117,15 @@ func ResourceIBMISVPC() *schema.Resource {
 		),
 
 		Schema: map[string]*schema.Schema{
+
+			"default_address_prefixes": {
+				Type: schema.TypeMap,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed:    true,
+				Description: "Default address prefixes for each zone.",
+			},
 			isVPCAddressPrefixManagement: {
 				Type:             schema.TypeString,
 				Optional:         true,
@@ -937,6 +946,51 @@ func vpcGet(d *schema.ResourceData, meta interface{}, id string) error {
 		return fmt.Errorf("[ERROR] Error getting VPC : %s\n%s", err, response)
 	}
 
+	// address prefixes
+
+	vpcID := id // Assuming the VPC ID is stored in the resource ID
+
+	// Fetch all address prefixes for the VPC
+	startAdd := ""
+	allRecs := []vpcv1.AddressPrefix{}
+	for {
+		listVpcAddressPrefixesOptions := &vpcv1.ListVPCAddressPrefixesOptions{
+			VPCID: &vpcID,
+		}
+
+		if startAdd != "" {
+			listVpcAddressPrefixesOptions.Start = &startAdd
+		}
+
+		addressPrefixCollection, response, err := sess.ListVPCAddressPrefixes(listVpcAddressPrefixesOptions)
+		if err != nil {
+			log.Printf("[DEBUG] ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
+			return fmt.Errorf("ListVpcAddressPrefixesWithContext failed %s\n%s", err, response)
+		}
+
+		allRecs = append(allRecs, addressPrefixCollection.AddressPrefixes...)
+		startAdd = flex.GetNext(addressPrefixCollection.Next)
+		if startAdd == "" {
+			break
+		}
+	}
+
+	// Process address prefixes
+	defaultAddressPrefixes := map[string]string{}
+
+	for _, prefix := range allRecs {
+		zoneName := *prefix.Zone.Name
+		cidr := *prefix.CIDR
+		// Populate default_address_prefixes
+		if *prefix.IsDefault {
+			defaultAddressPrefixes[zoneName] = cidr
+		}
+	}
+
+	// Set the default_address_prefixes attribute in the Terraform state
+	if err := d.Set("default_address_prefixes", defaultAddressPrefixes); err != nil {
+		return fmt.Errorf("error setting default_address_prefixes: %w", err)
+	}
 	d.Set(isVPCName, *vpc.Name)
 	d.Set(isVPCClassicAccess, *vpc.ClassicAccess)
 	d.Set(isVPCStatus, *vpc.Status)

--- a/ibm/service/vpc/resource_ibm_is_vpc_test.go
+++ b/ibm/service/vpc/resource_ibm_is_vpc_test.go
@@ -962,3 +962,52 @@ func testAccCheckIBMISVPCNoSgAclRulesConfig(vpcname string) string {
 `, vpcname)
 
 }
+
+// default address prefixes
+
+func TestAccIBMISVPC_basicAddressPrefix(t *testing.T) {
+	var vpc string
+	name1 := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
+	name2 := fmt.Sprintf("terraformvpcuat-%d", acctest.RandIntRange(10, 100))
+	apm := "manual"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISVPCDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckIBMISVPCConfig(name1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPCExists("ibm_is_vpc.testacc_vpc", vpc),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "name", name1),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "default_network_acl_name", "dnwacln"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "default_security_group_name", "dsgn"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "default_routing_table_name", "drtn"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc", "tags.#", "2"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_vpc.testacc_vpc", "default_address_prefixes.%"),
+				),
+			},
+			{
+				Config: testAccCheckIBMISVPCConfig1(name2, apm),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISVPCExists("ibm_is_vpc.testacc_vpc1", vpc),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc1", "name", name2),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc1", "tags.#", "2"),
+					resource.TestCheckResourceAttrSet(
+						"ibm_is_vpc.testacc_vpc1", "cse_source_addresses.#"),
+					resource.TestCheckResourceAttr(
+						"ibm_is_vpc.testacc_vpc1", "default_address_prefixes.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/website/docs/r/is_vpc.html.markdown
+++ b/website/docs/r/is_vpc.html.markdown
@@ -186,6 +186,16 @@ In addition to all argument reference list, you can access the following attribu
 - `cse_source_addresses`- (List) A list of the cloud service endpoints that are associated with your VPC, including their source IP address and zone.
 	- `address` - (String) The IP address of the cloud service endpoint.
 	- `zone_name` - (String) The zone where the cloud service endpoint is located.
+- `default_address_prefixes` - (Map) A map of default address prefixes for each zone in the VPC. The keys are the zone names, and the values are the corresponding address prefixes.
+  Example:
+  ```hcl
+    default_address_prefixes    = {
+        "us-south-1" = "10.240.0.0/18"
+        "us-south-2" = "10.240.64.0/18"
+        "us-south-3" = "10.240.128.0/18"
+        "us-south-4" = "10.240.192.0/18"
+    }
+  ```
 - `default_security_group_crn` - (String) CRN of the default security group created and attached to the VPC. 
 - `default_security_group` - (String) The default security group ID created and attached to the VPC. 
 - `default_network_acl_crn`-  (String) CRN of the default network ACL ID created and attached to the VPC.


### PR DESCRIPTION
```
 % make testacc TEST=./ibm/service/vpc TESTARGS='-run=TestAccIBMISVPC_basicAddressPrefix'
=== RUN   TestAccIBMISVPC_basicAddressPrefix
--- PASS: TestAccIBMISVPC_basicAddressPrefix (166.10s)
PASS
ok      github.com/IBM-Cloud/terraform-provider-ibm/ibm/service/vpc     168.612s
```

![image](https://github.com/user-attachments/assets/cd459c08-2993-4f47-ba07-ba7bdff34060)

