### PR TITLE
fixed the importer for is_instance for volumes import

### DIFF
--- a/ibm/service/vpc/resource_ibm_is_instance.go
+++ b/ibm/service/vpc/resource_ibm_is_instance.go
@@ -166,7 +166,7 @@ func ResourceIBMISInstance() *schema.Resource {
 						}
 					}
 				}
-				d.Set(isInstanceVolumes, flex.NewStringSet(schema.HashString, volumes))
+				d.Set(isInstanceVolumes, volumes)
 				return []*schema.ResourceData{d}, nil
 			},
 		},

--- a/ibm/service/vpc/resource_ibm_is_instance_test.go
+++ b/ibm/service/vpc/resource_ibm_is_instance_test.go
@@ -4325,3 +4325,163 @@ func testAccCheckIBMISInstanceConfigWithProfileAndBandwidth(vpcname, subnetname,
 		wait_before_delete = false
 	}`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, name, acc.IsImage, profile, bandwidth, prefix, acc.ISZoneName)
 }
+
+// import test
+
+func TestAccIBMISInstance_VolumeAttachment(t *testing.T) {
+	var instance string
+	vpcname := fmt.Sprintf("tf-vpc-%d", acctest.RandIntRange(10, 100))
+	name := fmt.Sprintf("tf-instance-%d", acctest.RandIntRange(10, 100))
+	subnetname := fmt.Sprintf("tf-subnet-%d", acctest.RandIntRange(10, 100))
+	volname := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	volname2 := fmt.Sprintf("tf-vol-%d", acctest.RandIntRange(10, 100))
+	publicKey := strings.TrimSpace(`
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR
+`)
+	sshname := fmt.Sprintf("tf-ssh-%d", acctest.RandIntRange(10, 100))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMISInstanceDestroy,
+		Steps: []resource.TestStep{
+			// Step 1: Create instance with one volume
+			{
+				Config: testAccCheckIBMISInstanceVolumeConfig(vpcname, subnetname, sshname, publicKey, name, volname),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "volumes.#", "1"),
+					resource.TestCheckResourceAttrPair(
+						"ibm_is_instance.testacc_instance", "volumes.0", "ibm_is_volume.volume", "id"),
+				),
+			},
+			// Step 2: Import the instance
+			{
+				ResourceName:      "ibm_is_instance.testacc_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"wait_before_delete",
+					"keys",
+					"force_action",
+				},
+			},
+			// Step 3: Update instance with two volumes
+			{
+				Config: testAccCheckIBMISInstanceTwoVolumesConfig(vpcname, subnetname, sshname, publicKey, name, volname, volname2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMISInstanceExists("ibm_is_instance.testacc_instance", instance),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "name", name),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "zone", acc.ISZoneName),
+					resource.TestCheckResourceAttr(
+						"ibm_is_instance.testacc_instance", "volumes.#", "2"),
+				),
+			},
+			// Step 4: Import the updated instance
+			{
+				ResourceName:      "ibm_is_instance.testacc_instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"wait_before_delete",
+					"keys",
+					"force_action",
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckIBMISInstanceVolumeConfig(vpcname, subnetname, sshname, publicKey, name, volname string) string {
+	return fmt.Sprintf(`
+resource "ibm_is_vpc" "testacc_vpc" {
+	name = "%s"
+}
+  
+resource "ibm_is_subnet" "testacc_subnet" {
+	name            = "%s"
+	vpc             = ibm_is_vpc.testacc_vpc.id
+	zone            = "%s"
+	ipv4_cidr_block = "%s"
+}
+  
+resource "ibm_is_ssh_key" "testacc_sshkey" {
+	name       = "%s"
+	public_key = "%s"
+}
+
+resource "ibm_is_volume" "volume" {
+	name    = "%s"
+	zone    = "%s"
+	capacity = 100
+	profile  = "general-purpose"
+}
+  
+resource "ibm_is_instance" "testacc_instance" {
+	name    = "%s"
+	image   = "%s"
+	profile = "%s"
+	primary_network_interface {
+		subnet     = ibm_is_subnet.testacc_subnet.id
+	}
+	volumes = [ibm_is_volume.volume.id]
+	vpc     = ibm_is_vpc.testacc_vpc.id
+	zone    = "%s"
+	keys    = [ibm_is_ssh_key.testacc_sshkey.id]
+	wait_before_delete = false
+}`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, volname, acc.ISZoneName, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName)
+}
+
+func testAccCheckIBMISInstanceTwoVolumesConfig(vpcname, subnetname, sshname, publicKey, name, volname1, volname2 string) string {
+	return fmt.Sprintf(`
+resource "ibm_is_vpc" "testacc_vpc" {
+	name = "%s"
+}
+  
+resource "ibm_is_subnet" "testacc_subnet" {
+	name            = "%s"
+	vpc             = ibm_is_vpc.testacc_vpc.id
+	zone            = "%s"
+	ipv4_cidr_block = "%s"
+}
+  
+resource "ibm_is_ssh_key" "testacc_sshkey" {
+	name       = "%s"
+	public_key = "%s"
+}
+
+resource "ibm_is_volume" "volume" {
+	name     = "%s"
+	zone     = "%s"
+	capacity = 100
+	profile  = "general-purpose"
+}
+
+resource "ibm_is_volume" "volume2" {
+	name     = "%s"
+	zone     = "%s"
+	capacity = 100
+	profile  = "general-purpose"
+}
+  
+resource "ibm_is_instance" "testacc_instance" {
+	name    = "%s"
+	image   = "%s"
+	profile = "%s"
+	primary_network_interface {
+		subnet     = ibm_is_subnet.testacc_subnet.id
+	}
+	volumes = [ibm_is_volume.volume.id, ibm_is_volume.volume2.id]
+	vpc     = ibm_is_vpc.testacc_vpc.id
+	zone    = "%s"
+	keys    = [ibm_is_ssh_key.testacc_sshkey.id]
+	wait_before_delete = false
+}`, vpcname, subnetname, acc.ISZoneName, acc.ISCIDR, sshname, publicKey, volname1, acc.ISZoneName, volname2, acc.ISZoneName, name, acc.IsImage, acc.InstanceProfileName, acc.ISZoneName)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
